### PR TITLE
[황지환 | 0618] 인증 구현

### DIFF
--- a/apps/stock-api/build.gradle.kts
+++ b/apps/stock-api/build.gradle.kts
@@ -9,6 +9,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
+    // security
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("io.jsonwebtoken:jjwt-api:${project.properties["jjwtVersion"]}")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:${project.properties["jjwtVersion"]}")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:${project.properties["jjwtVersion"]}")
+
     // querydsl (Q-class 생성용 APT — annotationProcessor는 전이되지 않아 모듈별로 선언)
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
@@ -16,4 +22,5 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation("org.springframework.security:spring-security-test")
 }

--- a/apps/stock-api/src/main/java/com/momentum/application/AuthService.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/AuthService.java
@@ -1,0 +1,107 @@
+package com.momentum.application;
+
+import com.momentum.domain.member.Member;
+import com.momentum.domain.member.MemberRepository;
+import com.momentum.infrastructure.auth.JwtProvider;
+import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
+import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailResponse;
+import com.momentum.interfaces.api.auth.AuthV1Dto.FindPasswordRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.LoginRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
+import com.momentum.support.error.CoreException;
+import com.momentum.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtProvider jwtProvider;
+
+  @Transactional
+  public AuthTokens register(RegisterRequest request) {
+    memberRepository.findByEmail(request.email())
+        .ifPresent(member -> {
+          throw new CoreException(ErrorType.CONFLICT, "이미 가입된 이메일입니다: " + request.email());
+        });
+
+    Member member = memberRepository.save(Member.create(
+        request.email(),
+        passwordEncoder.encode(request.password()),
+        request.name(), // 별도 닉네임 입력이 없어 이름을 기본 닉네임으로 사용한다.
+        request.name(),
+        request.phoneNumber()));
+
+    return issueTokens(member.getId());
+  }
+
+  @Transactional(readOnly = true)
+  public AuthTokens login(LoginRequest request) {
+    Member member = memberRepository.findByEmail(request.email())
+        .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."));
+
+    if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+      throw new CoreException(ErrorType.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    return issueTokens(member.getId());
+  }
+
+  @Transactional(readOnly = true)
+  public FindEmailResponse findEmail(FindEmailRequest request) {
+    Member member = memberRepository.findByPhoneNumberAndName(request.phoneNumber(), request.name())
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "일치하는 회원을 찾을 수 없습니다."));
+    return new FindEmailResponse(member.getEmail());
+  }
+
+  @Transactional(readOnly = true)
+  public void findPassword(FindPasswordRequest request) {
+    // 계정 존재 여부를 노출하지 않기 위해, 회원이 있을 때만 재설정 링크를 발송하고 응답은 항상 동일하게 성공 처리한다.
+    memberRepository.findByEmailAndName(request.email(), request.name())
+        .ifPresent(member -> {
+          // TODO: 비밀번호 재설정 토큰 생성 후 이메일 발송 (메일 인프라 연동 필요)
+          log.info("비밀번호 재설정 링크 발송 요청: memberId={}", member.getId());
+        });
+  }
+
+  /**
+   * HttpOnly 쿠키의 refreshToken 으로 새 accessToken 을 발급한다.
+   */
+  @Transactional(readOnly = true)
+  public String refreshAccessToken(String refreshToken) {
+    if (refreshToken == null || refreshToken.isBlank()) {
+      throw new CoreException(ErrorType.UNAUTHORIZED, "리프레시 토큰이 없습니다.");
+    }
+    Long memberId = jwtProvider.resolveMemberId(refreshToken)
+        .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."));
+
+    memberRepository.findById(memberId)
+        .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "존재하지 않는 회원입니다."));
+
+    return jwtProvider.createAccessToken(memberId);
+  }
+
+  @Transactional(readOnly = true)
+  public AccountResponse getAccount(Long memberId) {
+    if (memberId == null) {
+      return new AccountResponse(false, null, null);
+    }
+    return memberRepository.findById(memberId)
+        .map(member -> new AccountResponse(true, member.getId(), member.getNickname()))
+        .orElseGet(() -> new AccountResponse(false, null, null));
+  }
+
+  private AuthTokens issueTokens(Long memberId) {
+    return new AuthTokens(
+        jwtProvider.createAccessToken(memberId),
+        jwtProvider.createRefreshToken(memberId));
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/application/AuthService.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/AuthService.java
@@ -1,16 +1,21 @@
 package com.momentum.application;
 
+import com.momentum.config.JwtProperties;
+import com.momentum.domain.auth.RefreshToken;
+import com.momentum.domain.auth.RefreshTokenRepository;
 import com.momentum.domain.member.Member;
 import com.momentum.domain.member.MemberRepository;
 import com.momentum.infrastructure.auth.JwtProvider;
 import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailResponse;
-import com.momentum.interfaces.api.auth.AuthV1Dto.FindPasswordRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.LoginRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordConfirmRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordVerifyRequest;
 import com.momentum.support.error.CoreException;
 import com.momentum.support.error.ErrorType;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,8 +28,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
   private final MemberRepository memberRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
+  private final JwtProperties jwtProperties;
 
   @Transactional
   public AuthTokens register(RegisterRequest request) {
@@ -36,14 +43,14 @@ public class AuthService {
     Member member = memberRepository.save(Member.create(
         request.email(),
         passwordEncoder.encode(request.password()),
-        request.name(), // 별도 닉네임 입력이 없어 이름을 기본 닉네임으로 사용한다.
+        request.name(),
         request.name(),
         request.phoneNumber()));
 
     return issueTokens(member.getId());
   }
 
-  @Transactional(readOnly = true)
+  @Transactional
   public AuthTokens login(LoginRequest request) {
     Member member = memberRepository.findByEmail(request.email())
         .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."));
@@ -63,30 +70,55 @@ public class AuthService {
   }
 
   @Transactional(readOnly = true)
-  public void findPassword(FindPasswordRequest request) {
-    // 계정 존재 여부를 노출하지 않기 위해, 회원이 있을 때만 재설정 링크를 발송하고 응답은 항상 동일하게 성공 처리한다.
-    memberRepository.findByEmailAndName(request.email(), request.name())
-        .ifPresent(member -> {
-          // TODO: 비밀번호 재설정 토큰 생성 후 이메일 발송 (메일 인프라 연동 필요)
-          log.info("비밀번호 재설정 링크 발송 요청: memberId={}", member.getId());
-        });
+  public String verifyForPasswordReset(ResetPasswordVerifyRequest request) {
+    Member member = memberRepository
+        .findByEmailAndNameAndPhoneNumber(request.email(), request.name(), request.phoneNumber())
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "일치하는 회원을 찾을 수 없습니다."));
+    return jwtProvider.createPasswordResetToken(member.getId(), Instant.now());
   }
 
-  /**
-   * HttpOnly 쿠키의 refreshToken 으로 새 accessToken 을 발급한다.
-   */
-  @Transactional(readOnly = true)
-  public String refreshAccessToken(String refreshToken) {
+  @Transactional
+  public void confirmPasswordReset(String resetToken, ResetPasswordConfirmRequest request) {
+    if (resetToken == null || resetToken.isBlank()) {
+      throw new CoreException(ErrorType.UNAUTHORIZED, "본인확인이 필요합니다.");
+    }
+    if (request.newPassword() == null || request.newPassword().isBlank()) {
+      throw new CoreException(ErrorType.BAD_REQUEST, "새 비밀번호를 입력해주세요.");
+    }
+    Long memberId = jwtProvider.resolvePasswordResetMemberId(resetToken)
+        .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "유효하지 않거나 만료된 본인확인 정보입니다."));
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 회원입니다."));
+
+    member.changePassword(passwordEncoder.encode(request.newPassword()));
+    memberRepository.save(member);
+  }
+
+  @Transactional
+  public AuthTokens reissueRefreshToken(String refreshToken) {
     if (refreshToken == null || refreshToken.isBlank()) {
       throw new CoreException(ErrorType.UNAUTHORIZED, "리프레시 토큰이 없습니다.");
     }
     Long memberId = jwtProvider.resolveMemberId(refreshToken)
         .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."));
-
     memberRepository.findById(memberId)
         .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "존재하지 않는 회원입니다."));
 
-    return jwtProvider.createAccessToken(memberId);
+    RefreshToken savedRefreshToken = refreshTokenRepository.findActiveByToken(refreshToken)
+        .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "무효화된 리프레시 토큰입니다."));
+    savedRefreshToken.delete();
+
+    return issueTokens(memberId);
+  }
+
+  @Transactional
+  public void logout(String refreshToken) {
+    if (refreshToken == null || refreshToken.isBlank()) {
+      return;
+    }
+    refreshTokenRepository.findActiveByToken(refreshToken)
+        .ifPresent(RefreshToken::delete);
   }
 
   @Transactional(readOnly = true)
@@ -100,8 +132,11 @@ public class AuthService {
   }
 
   private AuthTokens issueTokens(Long memberId) {
-    return new AuthTokens(
-        jwtProvider.createAccessToken(memberId),
-        jwtProvider.createRefreshToken(memberId));
+    Instant now = Instant.now();
+    String accessToken = jwtProvider.createAccessToken(memberId, now);
+    String refreshToken = jwtProvider.createRefreshToken(memberId, now);
+    Instant expiresAt = now.plus(jwtProperties.refreshTokenValidity());
+    refreshTokenRepository.save(RefreshToken.issue(memberId, refreshToken, expiresAt));
+    return new AuthTokens(accessToken, refreshToken);
   }
 }

--- a/apps/stock-api/src/main/java/com/momentum/application/AuthTokens.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/AuthTokens.java
@@ -1,0 +1,9 @@
+package com.momentum.application;
+
+/** 인증 성공 시 발급되는 토큰 쌍. accessToken 은 응답 본문, refreshToken 은 HttpOnly 쿠키로 내려간다. */
+public record AuthTokens(
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/apps/stock-api/src/main/java/com/momentum/application/AuthTokens.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/AuthTokens.java
@@ -1,6 +1,5 @@
 package com.momentum.application;
 
-/** 인증 성공 시 발급되는 토큰 쌍. accessToken 은 응답 본문, refreshToken 은 HttpOnly 쿠키로 내려간다. */
 public record AuthTokens(
     String accessToken,
     String refreshToken

--- a/apps/stock-api/src/main/java/com/momentum/application/RankingService.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/RankingService.java
@@ -31,6 +31,7 @@ public class RankingService {
     List<BreakoutSuccessItem> stocks = findRanked(StockRegime.BREAKOUT_SUCCESS, at).stream()
         .map(score -> new BreakoutSuccessItem(
             score.getStock().getName(),
+            score.getStock().getCode(),
             currentPrice(score.getStock().getCode(), at),
             score.getMomentum().getValue(),
             score.getFipScore().getFip()))
@@ -43,6 +44,7 @@ public class RankingService {
     List<BreakoutReadyItem> stocks = findRanked(StockRegime.BREAKOUT_READY, at).stream()
         .map(score -> new BreakoutReadyItem(
             score.getStock().getName(),
+            score.getStock().getCode(),
             currentPrice(score.getStock().getCode(), at),
             score.getMomentum().getValue(),
             score.getFipScore().getFip()))

--- a/apps/stock-api/src/main/java/com/momentum/application/SnapshotService.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/SnapshotService.java
@@ -32,11 +32,11 @@ public class SnapshotService {
 
   @Transactional
   public SnapshotCreateResponse create(SnapshotCreateRequest request) {
-    Stock stock = stockRepository.findById(request.stockId())
-        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "종목을 찾을 수 없습니다: " + request.stockId()));
+    Stock stock = stockRepository.findByStockCode(request.stockCode())
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "종목을 찾을 수 없습니다: " + request.stockCode()));
 
     long capturedPrice = stockCandleRepository.findRecentCandle(stock, LocalDate.now())
-        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "최신 캔들을 찾을 수 없습니다: " + request.stockId()))
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "최신 캔들을 찾을 수 없습니다: " + request.stockCode()))
         .getClosePrice();
 
     List<StockSnapShot> references = snapshotRepository.findAllByIds(request.referenceSnapshotIds());
@@ -55,7 +55,12 @@ public class SnapshotService {
     List<Long> referenceSnapshotIds = snapshot.getReferences().stream()
         .map(reference -> reference.getReferenced().getId())
         .toList();
-    return new SnapshotDetailResponse(referenceSnapshotIds, snapshot.getRecordedAt(),
+    return new SnapshotDetailResponse(
+        snapshot.getStock().getName(),
+        snapshot.getStock().getCode(),
+        snapshot.getJudgment(),
+        referenceSnapshotIds,
+        snapshot.getRecordedAt(),
         snapshot.getRetrospective());
   }
 
@@ -70,6 +75,7 @@ public class SnapshotService {
         .map(snapshot -> new SnapshotListItem(
             snapshot.getId(),
             snapshot.getStock().getName(),
+            snapshot.getStock().getCode(),
             snapshot.getCapturedRegime(),
             snapshot.getJudgment(),
             snapshot.getRecordedAt(),

--- a/apps/stock-api/src/main/java/com/momentum/application/StockQueryService.java
+++ b/apps/stock-api/src/main/java/com/momentum/application/StockQueryService.java
@@ -2,6 +2,8 @@ package com.momentum.application;
 
 import com.momentum.domain.stock.Stock;
 import com.momentum.domain.stock.StockRepository;
+import com.momentum.support.error.CoreException;
+import com.momentum.support.error.ErrorType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,8 +15,14 @@ public class StockQueryService {
 
   private final StockRepository stockRepository;
 
-  @Transactional
+  @Transactional(readOnly = true)
   public List<Stock> search(String query) {
     return stockRepository.search(query);
+  }
+
+  @Transactional(readOnly = true)
+  public Stock getByCode(String stockCode) {
+    return stockRepository.findByStockCode(stockCode)
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "종목을 찾을 수 없습니다: " + stockCode));
   }
 }

--- a/apps/stock-api/src/main/java/com/momentum/config/JwtProperties.java
+++ b/apps/stock-api/src/main/java/com/momentum/config/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.momentum.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * JWT 서명 키와 토큰 만료 시간 설정. ({@code security.jwt.*})
+ */
+@ConfigurationProperties("security.jwt")
+public record JwtProperties(
+    String secret,
+    Duration accessTokenValidity,
+    Duration refreshTokenValidity
+) {
+
+}

--- a/apps/stock-api/src/main/java/com/momentum/config/JwtProperties.java
+++ b/apps/stock-api/src/main/java/com/momentum/config/JwtProperties.java
@@ -10,7 +10,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record JwtProperties(
     String secret,
     Duration accessTokenValidity,
-    Duration refreshTokenValidity
+    Duration refreshTokenValidity,
+    Duration passwordResetTokenValidity
 ) {
 
 }

--- a/apps/stock-api/src/main/java/com/momentum/config/SecurityConfig.java
+++ b/apps/stock-api/src/main/java/com/momentum/config/SecurityConfig.java
@@ -13,12 +13,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.OrRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -31,21 +25,17 @@ public class SecurityConfig {
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http,
-      CsrfTokenRepository csrfTokenRepository) throws Exception {
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-        .csrf(csrf -> csrf
-            .csrfTokenRepository(csrfTokenRepository)
-            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
-            // 명세상 CSRF 토큰이 필요한 엔드포인트는 login/refresh/logout 뿐이다.
-            .requireCsrfProtectionMatcher(csrfProtectedMatcher()))
+        .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-        // 아직 도메인 엔드포인트는 인증을 강제하지 않는다(기존 동작 유지). 토큰이 있으면 인증 정보만 채운다.
-        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers(JwtAuthenticationFilter.PROTECTED_PATTERNS).authenticated()
+            .anyRequest().permitAll())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
@@ -56,28 +46,9 @@ public class SecurityConfig {
     return new BCryptPasswordEncoder();
   }
 
-  /** 쿠키 이름 {@code csrfToken}, 헤더 이름 {@code X-CSRF-Token} 으로 명세에 맞춘다. */
-  @Bean
-  @SuppressWarnings("deprecation") // setCookieName 은 deprecated 이나 customizer 로는 쿠키 이름을 바꿀 수 없다.
-  public CsrfTokenRepository csrfTokenRepository() {
-    CookieCsrfTokenRepository repository = CookieCsrfTokenRepository.withHttpOnlyFalse();
-    repository.setHeaderName("X-CSRF-Token");
-    repository.setCookieName("csrfToken");
-    repository.setCookieCustomizer(cookie -> cookie.path("/"));
-    return repository;
-  }
-
-  private RequestMatcher csrfProtectedMatcher() {
-    return new OrRequestMatcher(
-        new AntPathRequestMatcher("/api/v1/auth/login", "POST"),
-        new AntPathRequestMatcher("/api/v1/auth/refresh", "POST"),
-        new AntPathRequestMatcher("/api/v1/auth/logout", "POST"));
-  }
-
-  /** 프론트엔드가 쿠키(refreshToken/csrfToken)를 주고받으므로 credentials 를 허용한다. 운영 도메인은 환경에 맞게 조정 필요. */
   private CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration config = new CorsConfiguration();
-    config.setAllowedOriginPatterns(List.of("http://localhost:*"));
+    config.setAllowedOriginPatterns(List.of("http://localhost:*")); // 추후 도메인에 맞게 수정필요
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     config.setAllowedHeaders(List.of("*"));
     config.setAllowCredentials(true);

--- a/apps/stock-api/src/main/java/com/momentum/config/SecurityConfig.java
+++ b/apps/stock-api/src/main/java/com/momentum/config/SecurityConfig.java
@@ -1,0 +1,89 @@
+package com.momentum.config;
+
+import com.momentum.infrastructure.auth.JwtAuthenticationFilter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http,
+      CsrfTokenRepository csrfTokenRepository) throws Exception {
+    http
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .csrf(csrf -> csrf
+            .csrfTokenRepository(csrfTokenRepository)
+            .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+            // 명세상 CSRF 토큰이 필요한 엔드포인트는 login/refresh/logout 뿐이다.
+            .requireCsrfProtectionMatcher(csrfProtectedMatcher()))
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .formLogin(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        // 아직 도메인 엔드포인트는 인증을 강제하지 않는다(기존 동작 유지). 토큰이 있으면 인증 정보만 채운다.
+        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  /** 쿠키 이름 {@code csrfToken}, 헤더 이름 {@code X-CSRF-Token} 으로 명세에 맞춘다. */
+  @Bean
+  @SuppressWarnings("deprecation") // setCookieName 은 deprecated 이나 customizer 로는 쿠키 이름을 바꿀 수 없다.
+  public CsrfTokenRepository csrfTokenRepository() {
+    CookieCsrfTokenRepository repository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+    repository.setHeaderName("X-CSRF-Token");
+    repository.setCookieName("csrfToken");
+    repository.setCookieCustomizer(cookie -> cookie.path("/"));
+    return repository;
+  }
+
+  private RequestMatcher csrfProtectedMatcher() {
+    return new OrRequestMatcher(
+        new AntPathRequestMatcher("/api/v1/auth/login", "POST"),
+        new AntPathRequestMatcher("/api/v1/auth/refresh", "POST"),
+        new AntPathRequestMatcher("/api/v1/auth/logout", "POST"));
+  }
+
+  /** 프론트엔드가 쿠키(refreshToken/csrfToken)를 주고받으므로 credentials 를 허용한다. 운영 도메인은 환경에 맞게 조정 필요. */
+  private CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOriginPatterns(List.of("http://localhost:*"));
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/domain/auth/RefreshToken.java
+++ b/apps/stock-api/src/main/java/com/momentum/domain/auth/RefreshToken.java
@@ -1,0 +1,35 @@
+package com.momentum.domain.auth;
+
+import com.momentum.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "refresh_token", indexes = @Index(name = "idx_refresh_token_token", columnList = "token"))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+  private Long memberId;
+
+  @Column(length = 512)
+  private String token;
+
+  private Instant expiresAt;
+
+  private RefreshToken(Long memberId, String token, Instant expiresAt) {
+    this.memberId = memberId;
+    this.token = token;
+    this.expiresAt = expiresAt;
+  }
+
+  public static RefreshToken issue(Long memberId, String token, Instant expiresAt) {
+    return new RefreshToken(memberId, token, expiresAt);
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/domain/auth/RefreshTokenRepository.java
+++ b/apps/stock-api/src/main/java/com/momentum/domain/auth/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.momentum.domain.auth;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+  RefreshToken save(RefreshToken refreshToken);
+
+  Optional<RefreshToken> findActiveByToken(String token);
+}

--- a/apps/stock-api/src/main/java/com/momentum/domain/member/Member.java
+++ b/apps/stock-api/src/main/java/com/momentum/domain/member/Member.java
@@ -36,6 +36,13 @@ public class Member extends BaseEntity {
     return new Member(email, password, nickname, name, phoneNumber);
   }
 
+  public void changePassword(String encodedPassword) {
+    if (encodedPassword == null || encodedPassword.isBlank()) {
+      throw new IllegalArgumentException("비밀번호는 비어있을 수 없습니다.");
+    }
+    this.password = encodedPassword;
+  }
+
   @Override
   protected void guard() {
     if (email == null || email.isBlank()) {

--- a/apps/stock-api/src/main/java/com/momentum/domain/member/MemberRepository.java
+++ b/apps/stock-api/src/main/java/com/momentum/domain/member/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository {
   Optional<Member> findByPhoneNumberAndName(String phoneNumber, String name);
 
   Optional<Member> findByEmailAndName(String email, String name);
+
+  Optional<Member> findByEmailAndNameAndPhoneNumber(String email, String name, String phoneNumber);
 }

--- a/apps/stock-api/src/main/java/com/momentum/domain/member/MemberRepository.java
+++ b/apps/stock-api/src/main/java/com/momentum/domain/member/MemberRepository.java
@@ -9,4 +9,8 @@ public interface MemberRepository {
   Optional<Member> findById(Long id);
 
   Optional<Member> findByEmail(String email);
+
+  Optional<Member> findByPhoneNumberAndName(String phoneNumber, String name);
+
+  Optional<Member> findByEmailAndName(String email, String name);
 }

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtAuthenticationFilter.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtAuthenticationFilter.java
@@ -1,54 +1,85 @@
 package com.momentum.infrastructure.auth;
 
+import com.momentum.support.error.CoreException;
+import com.momentum.support.error.ErrorType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
-/**
- * Authorization: Bearer accessToken 을 검증해 SecurityContext 에 인증 정보를 채운다.
- * 토큰이 없거나 유효하지 않으면 인증을 채우지 않고 그대로 통과시킨다(선택적 인증).
- * principal 에는 회원 ID(Long) 를 담는다.
- */
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-  private static final String BEARER_PREFIX = "Bearer ";
+  public static final String ACCESS_TOKEN_COOKIE = "accessToken";
+
+  private static final String ROLE_USER = "ROLE_USER";
+
+  public static final String[] PROTECTED_PATTERNS = {
+      "/api/v1/auth/account",
+      "/api/v1/snapshots",
+      "/api/v1/snapshots/**",
+      "/api/v1/stocks/*/like",
+      "/api/v1/stocks/likes"
+  };
+
+  private static final RequestMatcher PROTECTED_MATCHER = new OrRequestMatcher(
+      Arrays.stream(PROTECTED_PATTERNS)
+          .<RequestMatcher>map(AntPathRequestMatcher::new)
+          .toList());
 
   private final JwtProvider jwtProvider;
+  private final HandlerExceptionResolver handlerExceptionResolver;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    resolveToken(request)
-        .flatMap(jwtProvider::resolveMemberId)
-        .ifPresent(memberId -> authenticate(memberId, request));
-    filterChain.doFilter(request, response);
-  }
-
-  private java.util.Optional<String> resolveToken(HttpServletRequest request) {
-    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
-    if (header != null && header.startsWith(BEARER_PREFIX)) {
-      return java.util.Optional.of(header.substring(BEARER_PREFIX.length()));
+    try {
+      if (PROTECTED_MATCHER.matches(request)) {
+        Long memberId = jwtProvider.resolveMemberId(resolveToken(request))
+            .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "유효하지 않은 토큰입니다."));
+        authenticate(memberId);
+      }
+      filterChain.doFilter(request, response);
+    } catch (CoreException e) {
+      handlerExceptionResolver.resolveException(request, response, null, e);
     }
-    return java.util.Optional.empty();
   }
 
-  private void authenticate(Long memberId, HttpServletRequest request) {
-    var authentication = new UsernamePasswordAuthenticationToken(
-        memberId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
-    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+  private String resolveToken(HttpServletRequest request) {
+    return findAccessToken(request)
+        .orElseThrow(() -> new CoreException(ErrorType.UNAUTHORIZED, "로그인이 필요합니다."));
+  }
+
+  private Optional<String> findAccessToken(HttpServletRequest request) {
+    if (request.getCookies() == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(request.getCookies())
+        .filter(cookie -> ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+        .map(Cookie::getValue)
+        .filter(value -> value != null && !value.isBlank())
+        .findFirst();
+  }
+
+  private void authenticate(Long memberId) {
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+        memberId, null, List.of(new SimpleGrantedAuthority(ROLE_USER)));
     SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 }

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtAuthenticationFilter.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.momentum.infrastructure.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Authorization: Bearer accessToken 을 검증해 SecurityContext 에 인증 정보를 채운다.
+ * 토큰이 없거나 유효하지 않으면 인증을 채우지 않고 그대로 통과시킨다(선택적 인증).
+ * principal 에는 회원 ID(Long) 를 담는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    resolveToken(request)
+        .flatMap(jwtProvider::resolveMemberId)
+        .ifPresent(memberId -> authenticate(memberId, request));
+    filterChain.doFilter(request, response);
+  }
+
+  private java.util.Optional<String> resolveToken(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (header != null && header.startsWith(BEARER_PREFIX)) {
+      return java.util.Optional.of(header.substring(BEARER_PREFIX.length()));
+    }
+    return java.util.Optional.empty();
+  }
+
+  private void authenticate(Long memberId, HttpServletRequest request) {
+    var authentication = new UsernamePasswordAuthenticationToken(
+        memberId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtProvider.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtProvider.java
@@ -1,0 +1,64 @@
+package com.momentum.infrastructure.auth;
+
+import com.momentum.config.JwtProperties;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
+
+/**
+ * accessToken / refreshToken(JWT, HS256) 발급 및 검증.
+ * 토큰의 subject 에 회원 ID 를 담는다. 서버는 무상태로 서명만 검증한다.
+ */
+@Component
+public class JwtProvider {
+
+  private final SecretKey key;
+  private final Duration accessTokenValidity;
+  private final Duration refreshTokenValidity;
+
+  public JwtProvider(JwtProperties jwtProperties) {
+    this.key = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+    this.accessTokenValidity = jwtProperties.accessTokenValidity();
+    this.refreshTokenValidity = jwtProperties.refreshTokenValidity();
+  }
+
+  public String createAccessToken(Long memberId) {
+    return createToken(memberId, accessTokenValidity);
+  }
+
+  public String createRefreshToken(Long memberId) {
+    return createToken(memberId, refreshTokenValidity);
+  }
+
+  /** 토큰이 유효하면 회원 ID 를, 만료/위변조 시 비어있는 Optional 을 반환한다. */
+  public Optional<Long> resolveMemberId(String token) {
+    try {
+      String subject = Jwts.parser()
+          .verifyWith(key)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload()
+          .getSubject();
+      return Optional.of(Long.valueOf(subject));
+    } catch (JwtException | IllegalArgumentException e) {
+      return Optional.empty();
+    }
+  }
+
+  private String createToken(Long memberId, Duration validity) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + validity.toMillis());
+    return Jwts.builder()
+        .subject(String.valueOf(memberId))
+        .issuedAt(now)
+        .expiration(expiration)
+        .signWith(key)
+        .compact();
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtProvider.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/JwtProvider.java
@@ -1,42 +1,56 @@
 package com.momentum.infrastructure.auth;
 
 import com.momentum.config.JwtProperties;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import org.springframework.stereotype.Component;
 
-/**
- * accessToken / refreshToken(JWT, HS256) 발급 및 검증.
- * 토큰의 subject 에 회원 ID 를 담는다. 서버는 무상태로 서명만 검증한다.
- */
 @Component
 public class JwtProvider {
+
+  private static final String PURPOSE_CLAIM = "purpose";
+  private static final String PASSWORD_RESET_PURPOSE = "PASSWORD_RESET";
 
   private final SecretKey key;
   private final Duration accessTokenValidity;
   private final Duration refreshTokenValidity;
+  private final Duration passwordResetTokenValidity;
 
   public JwtProvider(JwtProperties jwtProperties) {
     this.key = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
     this.accessTokenValidity = jwtProperties.accessTokenValidity();
     this.refreshTokenValidity = jwtProperties.refreshTokenValidity();
+    this.passwordResetTokenValidity = jwtProperties.passwordResetTokenValidity();
   }
 
-  public String createAccessToken(Long memberId) {
-    return createToken(memberId, accessTokenValidity);
+  public String createAccessToken(Long memberId, Instant now) {
+    return createToken(memberId, accessTokenValidity, now);
   }
 
-  public String createRefreshToken(Long memberId) {
-    return createToken(memberId, refreshTokenValidity);
+  public String createRefreshToken(Long memberId, Instant now) {
+    return createToken(memberId, refreshTokenValidity, now);
   }
 
-  /** 토큰이 유효하면 회원 ID 를, 만료/위변조 시 비어있는 Optional 을 반환한다. */
+  public String createPasswordResetToken(Long memberId, Instant now) {
+    return Jwts.builder()
+        .id(UUID.randomUUID().toString())
+        .subject(String.valueOf(memberId))
+        .claim(PURPOSE_CLAIM, PASSWORD_RESET_PURPOSE)
+        .issuedAt(Date.from(now))
+        .expiration(Date.from(now.plus(passwordResetTokenValidity)))
+        .signWith(key)
+        .compact();
+  }
+
   public Optional<Long> resolveMemberId(String token) {
     try {
       String subject = Jwts.parser()
@@ -51,13 +65,28 @@ public class JwtProvider {
     }
   }
 
-  private String createToken(Long memberId, Duration validity) {
-    Date now = new Date();
-    Date expiration = new Date(now.getTime() + validity.toMillis());
+  public Optional<Long> resolvePasswordResetMemberId(String token) {
+    try {
+      Claims claims = Jwts.parser()
+          .verifyWith(key)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
+      if (!PASSWORD_RESET_PURPOSE.equals(claims.get(PURPOSE_CLAIM, String.class))) {
+        return Optional.empty();
+      }
+      return Optional.of(Long.valueOf(claims.getSubject()));
+    } catch (JwtException | IllegalArgumentException e) {
+      return Optional.empty();
+    }
+  }
+
+  private String createToken(Long memberId, Duration validity, Instant now) {
     return Jwts.builder()
+        .id(UUID.randomUUID().toString())
         .subject(String.valueOf(memberId))
-        .issuedAt(now)
-        .expiration(expiration)
+        .issuedAt(Date.from(now))
+        .expiration(Date.from(now.plus(validity)))
         .signWith(key)
         .compact();
   }

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/RefreshTokenJpaRepository.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/RefreshTokenJpaRepository.java
@@ -1,0 +1,10 @@
+package com.momentum.infrastructure.auth;
+
+import com.momentum.domain.auth.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
+
+  Optional<RefreshToken> findByTokenAndDeletedAtIsNull(String token);
+}

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/RefreshTokenRepositoryImpl.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/auth/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.momentum.infrastructure.auth;
+
+import com.momentum.domain.auth.RefreshToken;
+import com.momentum.domain.auth.RefreshTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+  private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+
+  @Override
+  public RefreshToken save(RefreshToken refreshToken) {
+    return refreshTokenJpaRepository.save(refreshToken);
+  }
+
+  @Override
+  public Optional<RefreshToken> findActiveByToken(String token) {
+    return refreshTokenJpaRepository.findByTokenAndDeletedAtIsNull(token);
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberJpaRepository.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberJpaRepository.java
@@ -11,4 +11,6 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
   Optional<Member> findByPhoneNumberAndName(String phoneNumber, String name);
 
   Optional<Member> findByEmailAndName(String email, String name);
+
+  Optional<Member> findByEmailAndNameAndPhoneNumber(String email, String name, String phoneNumber);
 }

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberJpaRepository.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberJpaRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByEmail(String email);
+
+  Optional<Member> findByPhoneNumberAndName(String phoneNumber, String name);
+
+  Optional<Member> findByEmailAndName(String email, String name);
 }

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberRepositoryImpl.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberRepositoryImpl.java
@@ -26,4 +26,14 @@ public class MemberRepositoryImpl implements MemberRepository {
   public Optional<Member> findByEmail(String email) {
     return memberJpaRepository.findByEmail(email);
   }
+
+  @Override
+  public Optional<Member> findByPhoneNumberAndName(String phoneNumber, String name) {
+    return memberJpaRepository.findByPhoneNumberAndName(phoneNumber, name);
+  }
+
+  @Override
+  public Optional<Member> findByEmailAndName(String email, String name) {
+    return memberJpaRepository.findByEmailAndName(email, name);
+  }
 }

--- a/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberRepositoryImpl.java
+++ b/apps/stock-api/src/main/java/com/momentum/infrastructure/member/MemberRepositoryImpl.java
@@ -36,4 +36,10 @@ public class MemberRepositoryImpl implements MemberRepository {
   public Optional<Member> findByEmailAndName(String email, String name) {
     return memberJpaRepository.findByEmailAndName(email, name);
   }
+
+  @Override
+  public Optional<Member> findByEmailAndNameAndPhoneNumber(String email, String name,
+      String phoneNumber) {
+    return memberJpaRepository.findByEmailAndNameAndPhoneNumber(email, name, phoneNumber);
+  }
 }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1ApiSpec.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1ApiSpec.java
@@ -4,53 +4,45 @@ import com.momentum.interfaces.api.ApiResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailResponse;
-import com.momentum.interfaces.api.auth.AuthV1Dto.FindPasswordRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.LoginRequest;
-import com.momentum.interfaces.api.auth.AuthV1Dto.LoginResponse;
-import com.momentum.interfaces.api.auth.AuthV1Dto.RefreshResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
-import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterResponse;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordConfirmRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordVerifyRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Auth V1 API", description = "인증/인가 관련 API 입니다.")
 public interface AuthV1ApiSpec {
 
   @Operation(
-      summary = "CSRF 토큰 발급",
-      description = "페이지 진입 시 호출합니다. csrfToken을 Cookie로 발급합니다."
-  )
-  @io.swagger.v3.oas.annotations.responses.ApiResponse(
-      responseCode = "200",
-      headers = @Header(name = "Set-Cookie", description = "csrfToken=<token>; Path=/")
-  )
-  ResponseEntity<ApiResponse<Void>> csrf(@Parameter(hidden = true) HttpServletRequest request);
-
-  @Operation(
       summary = "로그인",
-      description = "이메일과 비밀번호로 로그인합니다. refreshToken은 HttpOnly Cookie로 내려갑니다."
+      description = "이메일과 비밀번호로 로그인합니다. accessToken/refreshToken 모두 HttpOnly Cookie 로 내려갑니다."
   )
   @io.swagger.v3.oas.annotations.responses.ApiResponse(
       responseCode = "200",
-      headers = @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Path=/api/v1/auth")
+      headers = {
+          @Header(name = "Set-Cookie", description = "accessToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/"),
+          @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth")
+      }
   )
-  @Parameter(name = "X-CSRF-Token", in = ParameterIn.HEADER, description = "CSRF 토큰", required = true)
-  ResponseEntity<ApiResponse<LoginResponse>> login(LoginRequest request);
+  ResponseEntity<ApiResponse<Void>> login(LoginRequest request);
 
   @Operation(
       summary = "회원가입",
-      description = "이메일, 비밀번호, 전화번호, 닉네임으로 회원가입합니다."
+      description = "이메일, 비밀번호, 전화번호, 닉네임으로 회원가입합니다. accessToken/refreshToken 모두 HttpOnly Cookie 로 내려갑니다."
   )
   @io.swagger.v3.oas.annotations.responses.ApiResponse(
       responseCode = "200",
-      headers = @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Path=/api/v1/auth")
+      headers = {
+          @Header(name = "Set-Cookie", description = "accessToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/"),
+          @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth")
+      }
   )
-  ResponseEntity<ApiResponse<RegisterResponse>> register(RegisterRequest request);
+  ResponseEntity<ApiResponse<Void>> register(RegisterRequest request);
 
   @Operation(
       summary = "이메일 찾기",
@@ -59,34 +51,66 @@ public interface AuthV1ApiSpec {
   ApiResponse<FindEmailResponse> findEmail(FindEmailRequest request);
 
   @Operation(
-      summary = "비밀번호 찾기",
-      description = "이메일로 비밀번호 재설정 링크를 발송합니다."
-  )
-  ApiResponse<Void> findPassword(FindPasswordRequest request);
-
-  @Operation(
-      summary = "토큰 재발급",
-      description = "HttpOnly Cookie의 refreshToken으로 새로운 accessToken을 발급합니다."
-  )
-  @Parameter(name = "refreshToken", in = ParameterIn.COOKIE, description = "리프레시 토큰", required = true)
-  @Parameter(name = "X-CSRF-Token", in = ParameterIn.HEADER, description = "CSRF 토큰", required = true)
-  ApiResponse<RefreshResponse> refresh(@Parameter(hidden = true) String refreshToken);
-
-  @Operation(
-      summary = "로그아웃",
-      description = "HttpOnly Cookie의 refreshToken을 만료시킵니다. accessToken은 TTL까지 자연 만료됩니다."
+      summary = "비밀번호 재설정 1단계 - 본인확인",
+      description = "이메일·이름·전화번호로 본인을 확인합니다. 일치하면 짧은 수명의 재설정 토큰을 "
+          + "HttpOnly Cookie(passwordResetToken)로 발급하고, 없으면 404 를 반환합니다. "
+          + "이어서 2단계(/password/reset)에서 새 비밀번호를 설정합니다."
   )
   @io.swagger.v3.oas.annotations.responses.ApiResponse(
       responseCode = "200",
-      headers = @Header(name = "Set-Cookie", description = "refreshToken=; HttpOnly; Path=/api/v1/auth; Max-Age=0")
+      headers = @Header(name = "Set-Cookie",
+          description = "passwordResetToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth/password")
   )
-  @Parameter(name = "X-CSRF-Token", in = ParameterIn.HEADER, description = "CSRF 토큰", required = true)
-  ResponseEntity<ApiResponse<Void>> logout();
+  ResponseEntity<ApiResponse<Void>> verifyForPasswordReset(ResetPasswordVerifyRequest request);
+
+  @Operation(
+      summary = "비밀번호 재설정 2단계 - 비밀번호 변경",
+      description = "1단계에서 발급된 재설정 토큰(Cookie)으로 새 비밀번호를 적용합니다. "
+          + "토큰이 없거나 만료/위변조되었으면 401 을 반환합니다."
+  )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "200",
+      headers = @Header(name = "Set-Cookie",
+          description = "passwordResetToken=; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth/password; Max-Age=0")
+  )
+  @Parameter(name = "passwordResetToken", in = ParameterIn.COOKIE, description = "1단계에서 발급된 재설정 토큰", required = true)
+  ResponseEntity<ApiResponse<Void>> resetPassword(
+      @Parameter(hidden = true) String resetToken,
+      ResetPasswordConfirmRequest request);
+
+  @Operation(
+      summary = "토큰 재발급",
+      description = "HttpOnly Cookie 의 refreshToken 으로 새 access/refresh 토큰을 발급(rotation)합니다. "
+          + "무효화된(로그아웃/탈퇴) refreshToken 이면 401 을 반환합니다."
+  )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "200",
+      headers = {
+          @Header(name = "Set-Cookie", description = "accessToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/"),
+          @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth")
+      }
+  )
+  @Parameter(name = "refreshToken", in = ParameterIn.COOKIE, description = "리프레시 토큰", required = true)
+  ResponseEntity<ApiResponse<Void>> refresh(@Parameter(hidden = true) String refreshToken);
+
+  @Operation(
+      summary = "로그아웃",
+      description = "refreshToken 을 화이트리스트에서 무효화하고 access/refresh 쿠키를 삭제합니다."
+  )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "200",
+      headers = {
+          @Header(name = "Set-Cookie", description = "accessToken=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0"),
+          @Header(name = "Set-Cookie", description = "refreshToken=; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth; Max-Age=0")
+      }
+  )
+  @Parameter(name = "refreshToken", in = ParameterIn.COOKIE, description = "리프레시 토큰", required = false)
+  ResponseEntity<ApiResponse<Void>> logout(@Parameter(hidden = true) String refreshToken);
 
   @Operation(
       summary = "계정 정보 조회",
-      description = "사이드바에 표시할 로그인 여부 및 계정 정보를 조회합니다."
+      description = "사이드바에 표시할 로그인 여부 및 계정 정보를 조회합니다. HttpOnly Cookie 의 accessToken 으로 인증합니다."
   )
-  @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Bearer <accessToken>", required = true)
+  @Parameter(name = "accessToken", in = ParameterIn.COOKIE, description = "액세스 토큰", required = false)
   ApiResponse<AccountResponse> getAccount(@Parameter(hidden = true) Long memberId);
 }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1ApiSpec.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1ApiSpec.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Auth V1 API", description = "인증/인가 관련 API 입니다.")
 public interface AuthV1ApiSpec {
@@ -27,7 +29,7 @@ public interface AuthV1ApiSpec {
       responseCode = "200",
       headers = @Header(name = "Set-Cookie", description = "csrfToken=<token>; Path=/")
   )
-  ApiResponse<Void> csrf();
+  ResponseEntity<ApiResponse<Void>> csrf(@Parameter(hidden = true) HttpServletRequest request);
 
   @Operation(
       summary = "로그인",
@@ -38,13 +40,17 @@ public interface AuthV1ApiSpec {
       headers = @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Path=/api/v1/auth")
   )
   @Parameter(name = "X-CSRF-Token", in = ParameterIn.HEADER, description = "CSRF 토큰", required = true)
-  ApiResponse<LoginResponse> login(LoginRequest request);
+  ResponseEntity<ApiResponse<LoginResponse>> login(LoginRequest request);
 
   @Operation(
       summary = "회원가입",
       description = "이메일, 비밀번호, 전화번호, 닉네임으로 회원가입합니다."
   )
-  ApiResponse<RegisterResponse> register(RegisterRequest request);
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "200",
+      headers = @Header(name = "Set-Cookie", description = "refreshToken=<token>; HttpOnly; Path=/api/v1/auth")
+  )
+  ResponseEntity<ApiResponse<RegisterResponse>> register(RegisterRequest request);
 
   @Operation(
       summary = "이메일 찾기",
@@ -64,19 +70,23 @@ public interface AuthV1ApiSpec {
   )
   @Parameter(name = "refreshToken", in = ParameterIn.COOKIE, description = "리프레시 토큰", required = true)
   @Parameter(name = "X-CSRF-Token", in = ParameterIn.HEADER, description = "CSRF 토큰", required = true)
-  ApiResponse<RefreshResponse> refresh();
+  ApiResponse<RefreshResponse> refresh(@Parameter(hidden = true) String refreshToken);
 
   @Operation(
       summary = "로그아웃",
       description = "HttpOnly Cookie의 refreshToken을 만료시킵니다. accessToken은 TTL까지 자연 만료됩니다."
   )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "200",
+      headers = @Header(name = "Set-Cookie", description = "refreshToken=; HttpOnly; Path=/api/v1/auth; Max-Age=0")
+  )
   @Parameter(name = "X-CSRF-Token", in = ParameterIn.HEADER, description = "CSRF 토큰", required = true)
-  ApiResponse<Void> logout();
+  ResponseEntity<ApiResponse<Void>> logout();
 
   @Operation(
       summary = "계정 정보 조회",
       description = "사이드바에 표시할 로그인 여부 및 계정 정보를 조회합니다."
   )
   @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Bearer <accessToken>", required = true)
-  ApiResponse<AccountResponse> getAccount();
+  ApiResponse<AccountResponse> getAccount(@Parameter(hidden = true) Long memberId);
 }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1Controller.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1Controller.java
@@ -1,27 +1,25 @@
 package com.momentum.interfaces.api.auth;
 
+import static org.springframework.boot.web.server.Cookie.SameSite.STRICT;
+
 import com.momentum.application.AuthService;
 import com.momentum.application.AuthTokens;
 import com.momentum.config.JwtProperties;
+import com.momentum.infrastructure.auth.JwtAuthenticationFilter;
 import com.momentum.interfaces.api.ApiResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailResponse;
-import com.momentum.interfaces.api.auth.AuthV1Dto.FindPasswordRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.LoginRequest;
-import com.momentum.interfaces.api.auth.AuthV1Dto.LoginResponse;
-import com.momentum.interfaces.api.auth.AuthV1Dto.RefreshResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
-import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterResponse;
-import jakarta.servlet.http.HttpServletRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordConfirmRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordVerifyRequest;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,41 +32,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/auth")
 public class AuthV1Controller implements AuthV1ApiSpec {
 
+  private static final String ACCESS_TOKEN_COOKIE = JwtAuthenticationFilter.ACCESS_TOKEN_COOKIE;
   private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+  private static final String PASSWORD_RESET_COOKIE = "passwordResetToken";
+  private static final String ACCESS_TOKEN_PATH = "/";
   private static final String REFRESH_TOKEN_PATH = "/api/v1/auth";
-  private static final String CSRF_COOKIE = "csrfToken";
+  private static final String PASSWORD_RESET_PATH = "/api/v1/auth/password";
 
   private final AuthService authService;
   private final JwtProperties jwtProperties;
-  private final CsrfTokenRepository csrfTokenRepository;
-
-  @GetMapping("/csrf")
-  @Override
-  public ResponseEntity<ApiResponse<Void>> csrf(HttpServletRequest request) {
-    CsrfToken token = csrfTokenRepository.generateToken(request);
-    // CSRF 토큰은 프론트가 읽어 X-CSRF-Token 헤더로 echo 해야 하므로 HttpOnly 가 아니다.
-    ResponseCookie cookie = ResponseCookie.from(CSRF_COOKIE, token.getToken())
-        .httpOnly(false)
-        .path("/")
-        .sameSite("Lax")
-        .build();
-    return withCookie(cookie, null);
-  }
 
   @PostMapping("/login")
   @Override
-  public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
-    AuthTokens tokens = authService.login(request);
-    return withCookie(refreshTokenCookie(tokens.refreshToken(), jwtProperties.refreshTokenValidity()),
-        new LoginResponse(tokens.accessToken()));
+  public ResponseEntity<ApiResponse<Void>> login(@RequestBody LoginRequest request) {
+    return issueTokenCookies(authService.login(request));
   }
 
   @PostMapping("/register")
   @Override
-  public ResponseEntity<ApiResponse<RegisterResponse>> register(@RequestBody RegisterRequest request) {
-    AuthTokens tokens = authService.register(request);
-    return withCookie(refreshTokenCookie(tokens.refreshToken(), jwtProperties.refreshTokenValidity()),
-        new RegisterResponse(tokens.accessToken()));
+  public ResponseEntity<ApiResponse<Void>> register(@RequestBody RegisterRequest request) {
+    return issueTokenCookies(authService.register(request));
   }
 
   @PostMapping("/email/find")
@@ -77,27 +60,49 @@ public class AuthV1Controller implements AuthV1ApiSpec {
     return ApiResponse.success(authService.findEmail(request));
   }
 
-  @PostMapping("/password/find")
+  @PostMapping("/password/verify")
   @Override
-  public ApiResponse<Void> findPassword(@RequestBody FindPasswordRequest request) {
-    authService.findPassword(request);
-    return ApiResponse.success(null);
+  public ResponseEntity<ApiResponse<Void>> verifyForPasswordReset(
+      @RequestBody ResetPasswordVerifyRequest request) {
+    String resetToken = authService.verifyForPasswordReset(request);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, secureCookie(PASSWORD_RESET_COOKIE, resetToken,
+            PASSWORD_RESET_PATH, jwtProperties.passwordResetTokenValidity()).toString())
+        .body(ApiResponse.success(null));
+  }
+
+  @PostMapping("/password/reset")
+  @Override
+  public ResponseEntity<ApiResponse<Void>> resetPassword(
+      @CookieValue(name = PASSWORD_RESET_COOKIE, required = false) String resetToken,
+      @RequestBody ResetPasswordConfirmRequest request) {
+    authService.confirmPasswordReset(resetToken, request);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE,
+            secureCookie(PASSWORD_RESET_COOKIE, "", PASSWORD_RESET_PATH, Duration.ZERO).toString())
+        .body(ApiResponse.success(null));
   }
 
   @PostMapping("/refresh")
   @Override
-  public ApiResponse<RefreshResponse> refresh(
+  public ResponseEntity<ApiResponse<Void>> refresh(
       @CookieValue(name = REFRESH_TOKEN_COOKIE, required = false) String refreshToken
   ) {
-    String accessToken = authService.refreshAccessToken(refreshToken);
-    return ApiResponse.success(new RefreshResponse(accessToken));
+    return issueTokenCookies(authService.reissueRefreshToken(refreshToken));
   }
 
   @PostMapping("/logout")
   @Override
-  public ResponseEntity<ApiResponse<Void>> logout() {
-    // maxAge 0 인 빈 쿠키로 refreshToken 을 만료시킨다.
-    return withCookie(refreshTokenCookie("", Duration.ZERO), null);
+  public ResponseEntity<ApiResponse<Void>> logout(
+      @CookieValue(name = REFRESH_TOKEN_COOKIE, required = false) String refreshToken
+  ) {
+    authService.logout(refreshToken);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE,
+            secureCookie(ACCESS_TOKEN_COOKIE, "", ACCESS_TOKEN_PATH, Duration.ZERO).toString())
+        .header(HttpHeaders.SET_COOKIE,
+            secureCookie(REFRESH_TOKEN_COOKIE, "", REFRESH_TOKEN_PATH, Duration.ZERO).toString())
+        .body(ApiResponse.success(null));
   }
 
   @GetMapping("/account")
@@ -106,18 +111,24 @@ public class AuthV1Controller implements AuthV1ApiSpec {
     return ApiResponse.success(authService.getAccount(memberId));
   }
 
-  private ResponseCookie refreshTokenCookie(String value, Duration maxAge) {
-    return ResponseCookie.from(REFRESH_TOKEN_COOKIE, value)
-        .httpOnly(true)
-        .path(REFRESH_TOKEN_PATH)
-        .maxAge(maxAge)
-        .sameSite("Lax")
-        .build();
+  private ResponseEntity<ApiResponse<Void>> issueTokenCookies(AuthTokens tokens) {
+    ResponseCookie access = secureCookie(ACCESS_TOKEN_COOKIE, tokens.accessToken(),
+        ACCESS_TOKEN_PATH, jwtProperties.accessTokenValidity());
+    ResponseCookie refresh = secureCookie(REFRESH_TOKEN_COOKIE, tokens.refreshToken(),
+        REFRESH_TOKEN_PATH, jwtProperties.refreshTokenValidity());
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, access.toString())
+        .header(HttpHeaders.SET_COOKIE, refresh.toString())
+        .body(ApiResponse.success(null));
   }
 
-  private <T> ResponseEntity<ApiResponse<T>> withCookie(ResponseCookie cookie, T data) {
-    return ResponseEntity.ok()
-        .header(HttpHeaders.SET_COOKIE, cookie.toString())
-        .body(ApiResponse.success(data));
+  private ResponseCookie secureCookie(String name, String value, String path, Duration maxAge) {
+    return ResponseCookie.from(name, value)
+        .httpOnly(true)
+        .secure(true)
+        .path(path)
+        .maxAge(maxAge)
+        .sameSite(STRICT.attributeValue())
+        .build();
   }
 }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1Controller.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1Controller.java
@@ -1,5 +1,8 @@
 package com.momentum.interfaces.api.auth;
 
+import com.momentum.application.AuthService;
+import com.momentum.application.AuthTokens;
+import com.momentum.config.JwtProperties;
 import com.momentum.interfaces.api.ApiResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
@@ -10,7 +13,16 @@ import com.momentum.interfaces.api.auth.AuthV1Dto.LoginResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RefreshResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,67 +34,90 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/auth")
 public class AuthV1Controller implements AuthV1ApiSpec {
 
+  private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+  private static final String REFRESH_TOKEN_PATH = "/api/v1/auth";
+  private static final String CSRF_COOKIE = "csrfToken";
+
+  private final AuthService authService;
+  private final JwtProperties jwtProperties;
+  private final CsrfTokenRepository csrfTokenRepository;
+
   @GetMapping("/csrf")
   @Override
-  public ApiResponse<Void> csrf() {
-    // TODO: AuthFacade 연결 (csrfToken Cookie 발급)
-    return ApiResponse.success(null);
+  public ResponseEntity<ApiResponse<Void>> csrf(HttpServletRequest request) {
+    CsrfToken token = csrfTokenRepository.generateToken(request);
+    // CSRF 토큰은 프론트가 읽어 X-CSRF-Token 헤더로 echo 해야 하므로 HttpOnly 가 아니다.
+    ResponseCookie cookie = ResponseCookie.from(CSRF_COOKIE, token.getToken())
+        .httpOnly(false)
+        .path("/")
+        .sameSite("Lax")
+        .build();
+    return withCookie(cookie, null);
   }
 
   @PostMapping("/login")
   @Override
-  public ApiResponse<LoginResponse> login(
-      @RequestBody LoginRequest request
-  ) {
-    // TODO: AuthFacade 연결
-    return ApiResponse.success(null);
+  public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
+    AuthTokens tokens = authService.login(request);
+    return withCookie(refreshTokenCookie(tokens.refreshToken(), jwtProperties.refreshTokenValidity()),
+        new LoginResponse(tokens.accessToken()));
   }
 
   @PostMapping("/register")
   @Override
-  public ApiResponse<RegisterResponse> register(
-      @RequestBody RegisterRequest request
-  ) {
-    // TODO: AuthFacade 연결
-    return ApiResponse.success(null);
+  public ResponseEntity<ApiResponse<RegisterResponse>> register(@RequestBody RegisterRequest request) {
+    AuthTokens tokens = authService.register(request);
+    return withCookie(refreshTokenCookie(tokens.refreshToken(), jwtProperties.refreshTokenValidity()),
+        new RegisterResponse(tokens.accessToken()));
   }
 
   @PostMapping("/email/find")
   @Override
-  public ApiResponse<FindEmailResponse> findEmail(
-      @RequestBody FindEmailRequest request
-  ) {
-    // TODO: AuthFacade 연결
-    return ApiResponse.success(null);
+  public ApiResponse<FindEmailResponse> findEmail(@RequestBody FindEmailRequest request) {
+    return ApiResponse.success(authService.findEmail(request));
   }
 
   @PostMapping("/password/find")
   @Override
-  public ApiResponse<Void> findPassword(
-      @RequestBody FindPasswordRequest request
-  ) {
-    // TODO: AuthFacade 연결
+  public ApiResponse<Void> findPassword(@RequestBody FindPasswordRequest request) {
+    authService.findPassword(request);
     return ApiResponse.success(null);
   }
 
   @PostMapping("/refresh")
   @Override
-  public ApiResponse<RefreshResponse> refresh() {
-    // TODO: AuthFacade 연결 (refreshToken은 HttpOnly Cookie에서 읽음)
-    return ApiResponse.success(null);
+  public ApiResponse<RefreshResponse> refresh(
+      @CookieValue(name = REFRESH_TOKEN_COOKIE, required = false) String refreshToken
+  ) {
+    String accessToken = authService.refreshAccessToken(refreshToken);
+    return ApiResponse.success(new RefreshResponse(accessToken));
   }
 
   @PostMapping("/logout")
   @Override
-  public ApiResponse<Void> logout() {
-    // TODO: AuthFacade 연결 (refreshToken Cookie 만료 처리)
-    return ApiResponse.success(null);
+  public ResponseEntity<ApiResponse<Void>> logout() {
+    // maxAge 0 인 빈 쿠키로 refreshToken 을 만료시킨다.
+    return withCookie(refreshTokenCookie("", Duration.ZERO), null);
   }
 
   @GetMapping("/account")
   @Override
-  public ApiResponse<AccountResponse> getAccount() {
-    // TODO: AccountFacade 연결
-    return ApiResponse.success(null);
+  public ApiResponse<AccountResponse> getAccount(@AuthenticationPrincipal Long memberId) {
+    return ApiResponse.success(authService.getAccount(memberId));
+  }
+
+  private ResponseCookie refreshTokenCookie(String value, Duration maxAge) {
+    return ResponseCookie.from(REFRESH_TOKEN_COOKIE, value)
+        .httpOnly(true)
+        .path(REFRESH_TOKEN_PATH)
+        .maxAge(maxAge)
+        .sameSite("Lax")
+        .build();
+  }
+
+  private <T> ResponseEntity<ApiResponse<T>> withCookie(ResponseCookie cookie, T data) {
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, cookie.toString())
+        .body(ApiResponse.success(data));
   }
 }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1Dto.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/auth/AuthV1Dto.java
@@ -11,12 +11,6 @@ public class AuthV1Dto {
 
   }
 
-  public record LoginResponse(
-      String accessToken
-  ) {
-
-  }
-
   // ===================== Register =====================
 
   public record RegisterRequest(
@@ -24,12 +18,6 @@ public class AuthV1Dto {
       String password,
       String name,
       String phoneNumber
-  ) {
-
-  }
-
-  public record RegisterResponse(
-      String accessToken
   ) {
 
   }
@@ -49,20 +37,18 @@ public class AuthV1Dto {
 
   }
 
-  // ===================== Find Password =====================
+  // ===================== Reset Password =====================
 
-  public record FindPasswordRequest(
+  public record ResetPasswordVerifyRequest(
       String email,
-      String name
+      String name,
+      String phoneNumber
   ) {
 
   }
 
-
-  // ===================== Refresh =====================
-
-  public record RefreshResponse(
-      String accessToken
+  public record ResetPasswordConfirmRequest(
+      String newPassword
   ) {
 
   }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/rank/RankingV1ApiSpec.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/rank/RankingV1ApiSpec.java
@@ -1,7 +1,6 @@
 package com.momentum.interfaces.api.rank;
 
 import com.momentum.interfaces.api.ApiResponse;
-import com.momentum.interfaces.api.rank.RankingV1Dto.BreakoutFailedResponse;
 import com.momentum.interfaces.api.rank.RankingV1Dto.BreakoutReadyResponse;
 import com.momentum.interfaces.api.rank.RankingV1Dto.BreakoutSuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 
-@Tag(name = "Ranking V1 API", description = "레짐별 랭킹 API 입니다. 돌파 성공/돌파준비/돌파실패 3개 레짐에 대해서만 랭킹을 제공합니다.")
+@Tag(name = "Ranking V1 API", description = "레짐별 랭킹 API 입니다. 돌파 성공/돌파준비 2개 레짐에 대해서만 랭킹을 제공합니다.")
 public interface RankingV1ApiSpec {
   // ===================== HTTP (스냅샷) =====================
 

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/rank/RankingV1Dto.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/rank/RankingV1Dto.java
@@ -12,6 +12,7 @@ public class RankingV1Dto {
     ) {
         public record BreakoutSuccessItem(
             String stockName,
+            String stockCode,
             BigDecimal currentPrice,
             BigDecimal oneYearMomentum,
             BigDecimal fipScore
@@ -25,6 +26,7 @@ public class RankingV1Dto {
     ) {
         public record BreakoutReadyItem(
             String stockName,
+            String stockCode,
             BigDecimal currentPrice,
             BigDecimal oneYearMomentum,
             BigDecimal fipScore

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/rank/RankingV1Dto.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/rank/RankingV1Dto.java
@@ -30,17 +30,4 @@ public class RankingV1Dto {
             BigDecimal fipScore
         ) {}
     }
-
-    // ===================== 돌파실패 (BREAKOUT_FAILED) =====================
-
-    public record BreakoutFailedResponse(
-        List<BreakoutFailedItem> stocks
-    ) {
-        public record BreakoutFailedItem(
-            String stockName,
-            BigDecimal currentPrice,
-            BigDecimal oneYearMomentum,
-            BigDecimal fipScore
-        ) {}
-    }
 }

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/snapshot/SnapshotV1Dto.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/snapshot/SnapshotV1Dto.java
@@ -20,6 +20,7 @@ public class SnapshotV1Dto {
     public record SnapshotListItem(
         Long snapshotId,
         String stockName,
+        String stockCode,
         StockRegime stockRegime,
         SnapshotJudgment judgment,
         LocalDateTime recordedAt,
@@ -32,6 +33,9 @@ public class SnapshotV1Dto {
   // ===================== Snapshot Detail =====================
 
   public record SnapshotDetailResponse(
+      String stockName,
+      String stockCode,
+      SnapshotJudgment judgment,
       List<Long> referenceSnapshotIds,
       LocalDateTime recordedAt,
       String retrospective
@@ -43,7 +47,7 @@ public class SnapshotV1Dto {
 
   // 스냅샷 생성 요청 (시작)
   public record SnapshotCreateRequest(
-      Long stockId,
+      String stockCode,
       SnapshotJudgment judgment,
       List<Long> referenceSnapshotIds,
       String retrospective

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/stock/StockMetaV1ApiSpec.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/stock/StockMetaV1ApiSpec.java
@@ -1,0 +1,19 @@
+package com.momentum.interfaces.api.stock;
+
+import com.momentum.interfaces.api.ApiResponse;
+import com.momentum.interfaces.api.stock.StockMetaV1Dto.StockMetaResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Stock Meta V1 API", description = "종목 메타데이터(이름/코드/레짐/추세) 조회 API")
+public interface StockMetaV1ApiSpec {
+
+  @Operation(
+      summary = "종목 메타 조회",
+      description = "종목코드로 종목명·현재 레짐·추세 등 메타데이터를 조회합니다."
+  )
+  ApiResponse<StockMetaResponse> getStockMeta(
+      @Parameter(description = "종목코드", example = "000660") String stockCode
+  );
+}

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/stock/StockMetaV1Controller.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/stock/StockMetaV1Controller.java
@@ -1,0 +1,27 @@
+package com.momentum.interfaces.api.stock;
+
+import com.momentum.application.StockQueryService;
+import com.momentum.interfaces.api.ApiResponse;
+import com.momentum.interfaces.api.stock.StockMetaV1Dto.StockMetaResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/stocks")
+public class StockMetaV1Controller implements StockMetaV1ApiSpec {
+
+  private final StockQueryService stockQueryService;
+
+  @GetMapping("/{stockCode}")
+  @Override
+  public ApiResponse<StockMetaResponse> getStockMeta(
+      @PathVariable String stockCode
+  ) {
+    return ApiResponse.success(
+        StockMetaResponse.from(stockQueryService.getByCode(stockCode)));
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/interfaces/api/stock/StockMetaV1Dto.java
+++ b/apps/stock-api/src/main/java/com/momentum/interfaces/api/stock/StockMetaV1Dto.java
@@ -1,0 +1,24 @@
+package com.momentum.interfaces.api.stock;
+
+import com.momentum.domain.stock.Stock;
+import com.momentum.domain.stock.StockRegime;
+import com.momentum.domain.stock.StockTrend;
+
+public class StockMetaV1Dto {
+
+  public record StockMetaResponse(
+      String stockCode,
+      String stockName,
+      StockRegime regime,
+      StockTrend trend
+  ) {
+
+    public static StockMetaResponse from(Stock stock) {
+      return new StockMetaResponse(
+          stock.getCode(),
+          stock.getName(),
+          stock.getStockRegime(),
+          stock.getStockTrend());
+    }
+  }
+}

--- a/apps/stock-api/src/main/java/com/momentum/support/error/ErrorType.java
+++ b/apps/stock-api/src/main/java/com/momentum/support/error/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
     /** 범용 에러 */
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, HttpStatus.UNAUTHORIZED.getReasonPhrase(), "인증에 실패했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
     CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
 

--- a/apps/stock-api/src/main/resources/application.yml
+++ b/apps/stock-api/src/main/resources/application.yml
@@ -28,6 +28,13 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+security:
+  jwt:
+    # HS256 키는 최소 32바이트 이상이어야 한다. 운영 환경에서는 반드시 환경변수로 덮어쓸 것.
+    secret: ${JWT_SECRET:local-dev-momentum-jwt-secret-key-please-change-0123456789}
+    access-token-validity: 30m
+    refresh-token-validity: 14d
+
 
 ---
 spring:

--- a/apps/stock-api/src/main/resources/application.yml
+++ b/apps/stock-api/src/main/resources/application.yml
@@ -32,8 +32,9 @@ security:
   jwt:
     # HS256 키는 최소 32바이트 이상이어야 한다. 운영 환경에서는 반드시 환경변수로 덮어쓸 것.
     secret: ${JWT_SECRET:local-dev-momentum-jwt-secret-key-please-change-0123456789}
-    access-token-validity: 30m
-    refresh-token-validity: 14d
+    access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY:30m}
+    refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY:14d}
+    password-reset-token-validity: ${JWT_PASSWORD_RESET_TOKEN_VALIDITY:10m}
 
 
 ---

--- a/apps/stock-api/src/test/java/com/momentum/application/AuthServiceTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/application/AuthServiceTest.java
@@ -1,0 +1,171 @@
+package com.momentum.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.momentum.domain.member.Member;
+import com.momentum.domain.member.MemberRepository;
+import com.momentum.infrastructure.auth.JwtProvider;
+import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
+import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailResponse;
+import com.momentum.interfaces.api.auth.AuthV1Dto.FindPasswordRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.LoginRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
+import com.momentum.support.error.CoreException;
+import com.momentum.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class AuthServiceTest {
+
+  @Autowired
+  private AuthService authService;
+  @Autowired
+  private MemberRepository memberRepository;
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+  @Autowired
+  private JwtProvider jwtProvider;
+
+  @Test
+  @DisplayName("회원가입 시 비밀번호는 암호화되어 저장되고 access/refresh 토큰이 발급된다")
+  void registerEncodesPasswordAndIssuesTokens() {
+    AuthTokens tokens = authService.register(register("a@momentum.com", "pw1234"));
+
+    Member member = memberRepository.findByEmail("a@momentum.com").orElseThrow();
+    assertThat(member.getPassword()).isNotEqualTo("pw1234");
+    assertThat(passwordEncoder.matches("pw1234", member.getPassword())).isTrue();
+    assertThat(jwtProvider.resolveMemberId(tokens.accessToken())).contains(member.getId());
+    assertThat(jwtProvider.resolveMemberId(tokens.refreshToken())).contains(member.getId());
+  }
+
+  @Test
+  @DisplayName("이미 가입된 이메일로 회원가입하면 CONFLICT")
+  void registerThrowsWhenEmailExists() {
+    authService.register(register("dup@momentum.com", "pw1234"));
+
+    assertThatThrownBy(() -> authService.register(register("dup@momentum.com", "other")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.CONFLICT);
+  }
+
+  @Test
+  @DisplayName("올바른 자격증명으로 로그인하면 회원의 토큰이 발급된다")
+  void loginSucceedsWithValidCredentials() {
+    Member member = memberRepository.findByEmail("login@momentum.com")
+        .orElseGet(() -> {
+          authService.register(register("login@momentum.com", "pw1234"));
+          return memberRepository.findByEmail("login@momentum.com").orElseThrow();
+        });
+
+    AuthTokens tokens = authService.login(new LoginRequest("login@momentum.com", "pw1234"));
+
+    assertThat(jwtProvider.resolveMemberId(tokens.accessToken())).contains(member.getId());
+  }
+
+  @Test
+  @DisplayName("비밀번호가 틀리면 UNAUTHORIZED")
+  void loginThrowsWhenPasswordWrong() {
+    authService.register(register("wrongpw@momentum.com", "pw1234"));
+
+    assertThatThrownBy(() -> authService.login(new LoginRequest("wrongpw@momentum.com", "nope")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 이메일로 로그인하면 UNAUTHORIZED")
+  void loginThrowsWhenEmailNotFound() {
+    assertThatThrownBy(() -> authService.login(new LoginRequest("ghost@momentum.com", "pw1234")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("전화번호와 이름으로 가입된 이메일을 찾는다")
+  void findEmailReturnsRegisteredEmail() {
+    authService.register(new RegisterRequest("find@momentum.com", "pw1234", "홍길동", "01011112222"));
+
+    FindEmailResponse response = authService.findEmail(new FindEmailRequest("01011112222", "홍길동"));
+
+    assertThat(response.email()).isEqualTo("find@momentum.com");
+  }
+
+  @Test
+  @DisplayName("일치하는 회원이 없으면 이메일 찾기는 NOT_FOUND")
+  void findEmailThrowsWhenNotFound() {
+    assertThatThrownBy(() -> authService.findEmail(new FindEmailRequest("00000000000", "없는사람")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("비밀번호 찾기는 회원 존재 여부와 무관하게 예외 없이 처리된다")
+  void findPasswordDoesNotThrow() {
+    authService.findPassword(new FindPasswordRequest("none@momentum.com", "없는사람"));
+  }
+
+  @Test
+  @DisplayName("유효한 refreshToken으로 새 accessToken을 발급한다")
+  void refreshIssuesNewAccessToken() {
+    AuthTokens tokens = authService.register(register("refresh@momentum.com", "pw1234"));
+    Long memberId = jwtProvider.resolveMemberId(tokens.refreshToken()).orElseThrow();
+
+    String accessToken = authService.refreshAccessToken(tokens.refreshToken());
+
+    assertThat(jwtProvider.resolveMemberId(accessToken)).contains(memberId);
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 refreshToken이면 UNAUTHORIZED")
+  void refreshThrowsWhenTokenInvalid() {
+    assertThatThrownBy(() -> authService.refreshAccessToken("invalid.token.value"))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("refreshToken이 없으면 UNAUTHORIZED")
+  void refreshThrowsWhenTokenMissing() {
+    assertThatThrownBy(() -> authService.refreshAccessToken(null))
+        .isInstanceOf(CoreException.class);
+  }
+
+  @Test
+  @DisplayName("로그인하지 않은 경우 계정 조회는 isLoggedIn=false")
+  void getAccountReturnsLoggedOutWhenNull() {
+    AccountResponse response = authService.getAccount(null);
+
+    assertThat(response.isLoggedIn()).isFalse();
+    assertThat(response.userId()).isNull();
+  }
+
+  @Test
+  @DisplayName("회원 ID가 있으면 계정 정보를 반환한다")
+  void getAccountReturnsMemberInfo() {
+    authService.register(register("account@momentum.com", "pw1234"));
+    Member member = memberRepository.findByEmail("account@momentum.com").orElseThrow();
+
+    AccountResponse response = authService.getAccount(member.getId());
+
+    assertThat(response.isLoggedIn()).isTrue();
+    assertThat(response.userId()).isEqualTo(member.getId());
+    assertThat(response.nickname()).isEqualTo(member.getNickname());
+  }
+
+  private RegisterRequest register(String email, String password) {
+    return new RegisterRequest(email, password, "이름", "01000000000");
+  }
+}

--- a/apps/stock-api/src/test/java/com/momentum/application/AuthServiceTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/application/AuthServiceTest.java
@@ -9,11 +9,14 @@ import com.momentum.infrastructure.auth.JwtProvider;
 import com.momentum.interfaces.api.auth.AuthV1Dto.AccountResponse;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.FindEmailResponse;
-import com.momentum.interfaces.api.auth.AuthV1Dto.FindPasswordRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.LoginRequest;
 import com.momentum.interfaces.api.auth.AuthV1Dto.RegisterRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordConfirmRequest;
+import com.momentum.interfaces.api.auth.AuthV1Dto.ResetPasswordVerifyRequest;
 import com.momentum.support.error.CoreException;
 import com.momentum.support.error.ErrorType;
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,26 +114,139 @@ class AuthServiceTest {
   }
 
   @Test
-  @DisplayName("비밀번호 찾기는 회원 존재 여부와 무관하게 예외 없이 처리된다")
-  void findPasswordDoesNotThrow() {
-    authService.findPassword(new FindPasswordRequest("none@momentum.com", "없는사람"));
+  @DisplayName("1단계 본인확인 통과 후 2단계에서 비밀번호가 변경된다")
+  void passwordResetTwoStepChangesPassword() {
+    authService.register(new RegisterRequest("reset@momentum.com", "oldpw", "홍길동", "01099998888"));
+
+    String resetToken = authService.verifyForPasswordReset(
+        new ResetPasswordVerifyRequest("reset@momentum.com", "홍길동", "01099998888"));
+    authService.confirmPasswordReset(resetToken, new ResetPasswordConfirmRequest("newpw1234"));
+
+    Member member = memberRepository.findByEmail("reset@momentum.com").orElseThrow();
+    assertThat(passwordEncoder.matches("newpw1234", member.getPassword())).isTrue();
+    assertThat(passwordEncoder.matches("oldpw", member.getPassword())).isFalse();
   }
 
   @Test
-  @DisplayName("유효한 refreshToken으로 새 accessToken을 발급한다")
-  void refreshIssuesNewAccessToken() {
+  @DisplayName("1단계 본인확인 정보가 일치하지 않으면 NOT_FOUND")
+  void passwordResetVerifyThrowsWhenIdentityMismatch() {
+    authService.register(new RegisterRequest("reset2@momentum.com", "oldpw", "홍길동", "01099998888"));
+
+    assertThatThrownBy(() -> authService.verifyForPasswordReset(
+        new ResetPasswordVerifyRequest("reset2@momentum.com", "다른이름", "01099998888")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("2단계에서 새 비밀번호가 비어있으면 BAD_REQUEST")
+  void passwordResetConfirmThrowsWhenNewPasswordBlank() {
+    authService.register(new RegisterRequest("reset3@momentum.com", "oldpw", "홍길동", "01099998888"));
+    String resetToken = authService.verifyForPasswordReset(
+        new ResetPasswordVerifyRequest("reset3@momentum.com", "홍길동", "01099998888"));
+
+    assertThatThrownBy(() ->
+        authService.confirmPasswordReset(resetToken, new ResetPasswordConfirmRequest("  ")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("2단계에서 재설정 토큰이 없으면 UNAUTHORIZED")
+  void passwordResetConfirmThrowsWhenTokenMissing() {
+    assertThatThrownBy(() ->
+        authService.confirmPasswordReset(null, new ResetPasswordConfirmRequest("newpw1234")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("재설정 토큰 대신 일반 accessToken을 쓰면(용도 불일치) UNAUTHORIZED")
+  void passwordResetConfirmRejectsNonResetToken() {
+    authService.register(new RegisterRequest("reset4@momentum.com", "oldpw", "홍길동", "01099998888"));
+    Member member = memberRepository.findByEmail("reset4@momentum.com").orElseThrow();
+    String accessToken = jwtProvider.createAccessToken(member.getId(), Instant.now());
+
+    assertThatThrownBy(() ->
+        authService.confirmPasswordReset(accessToken, new ResetPasswordConfirmRequest("newpw1234")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("만료된 재설정 토큰이면 UNAUTHORIZED")
+  void passwordResetConfirmThrowsWhenTokenExpired() {
+    authService.register(new RegisterRequest("reset5@momentum.com", "oldpw", "홍길동", "01099998888"));
+    Member member = memberRepository.findByEmail("reset5@momentum.com").orElseThrow();
+    // 재설정 토큰 유효기간(10분)보다 더 과거에 발급 → 이미 만료
+    String expired = jwtProvider.createPasswordResetToken(
+        member.getId(), Instant.now().minus(Duration.ofMinutes(11)));
+
+    assertThatThrownBy(() ->
+        authService.confirmPasswordReset(expired, new ResetPasswordConfirmRequest("newpw1234")))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("유효한 refreshToken으로 새 access/refresh 토큰 쌍을 발급한다")
+  void refreshIssuesNewTokens() {
     AuthTokens tokens = authService.register(register("refresh@momentum.com", "pw1234"));
     Long memberId = jwtProvider.resolveMemberId(tokens.refreshToken()).orElseThrow();
 
-    String accessToken = authService.refreshAccessToken(tokens.refreshToken());
+    AuthTokens refreshed = authService.reissueRefreshToken(tokens.refreshToken());
 
-    assertThat(jwtProvider.resolveMemberId(accessToken)).contains(memberId);
+    assertThat(jwtProvider.resolveMemberId(refreshed.accessToken())).contains(memberId);
+    assertThat(jwtProvider.resolveMemberId(refreshed.refreshToken())).contains(memberId);
+  }
+
+  @Test
+  @DisplayName("회전(rotation) 후 기존 refreshToken은 무효화되어 재사용할 수 없다")
+  void refreshRotationInvalidatesOldToken() {
+    AuthTokens tokens = authService.register(register("rotate@momentum.com", "pw1234"));
+
+    authService.reissueRefreshToken(tokens.refreshToken());
+
+    assertThatThrownBy(() -> authService.reissueRefreshToken(tokens.refreshToken()))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("로그아웃으로 무효화된 refreshToken이면 UNAUTHORIZED")
+  void refreshThrowsWhenTokenRevoked() {
+    AuthTokens tokens = authService.register(register("revoked@momentum.com", "pw1234"));
+    authService.logout(tokens.refreshToken());
+
+    assertThatThrownBy(() -> authService.reissueRefreshToken(tokens.refreshToken()))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("화이트리스트에 없는(저장되지 않은) refreshToken은 서명이 유효해도 UNAUTHORIZED")
+  void refreshThrowsWhenTokenNotWhitelisted() {
+    authService.register(register("nowhitelist@momentum.com", "pw1234"));
+    Member member = memberRepository.findByEmail("nowhitelist@momentum.com").orElseThrow();
+    String unsavedRefresh = jwtProvider.createRefreshToken(member.getId(), Instant.now());
+
+    assertThatThrownBy(() -> authService.reissueRefreshToken(unsavedRefresh))
+        .isInstanceOf(CoreException.class)
+        .extracting(e -> ((CoreException) e).getErrorType())
+        .isEqualTo(ErrorType.UNAUTHORIZED);
   }
 
   @Test
   @DisplayName("유효하지 않은 refreshToken이면 UNAUTHORIZED")
   void refreshThrowsWhenTokenInvalid() {
-    assertThatThrownBy(() -> authService.refreshAccessToken("invalid.token.value"))
+    assertThatThrownBy(() -> authService.reissueRefreshToken("invalid.token.value"))
         .isInstanceOf(CoreException.class)
         .extracting(e -> ((CoreException) e).getErrorType())
         .isEqualTo(ErrorType.UNAUTHORIZED);
@@ -139,7 +255,7 @@ class AuthServiceTest {
   @Test
   @DisplayName("refreshToken이 없으면 UNAUTHORIZED")
   void refreshThrowsWhenTokenMissing() {
-    assertThatThrownBy(() -> authService.refreshAccessToken(null))
+    assertThatThrownBy(() -> authService.reissueRefreshToken(null))
         .isInstanceOf(CoreException.class);
   }
 

--- a/apps/stock-api/src/test/java/com/momentum/application/SnapshotServiceTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/application/SnapshotServiceTest.java
@@ -50,7 +50,7 @@ class SnapshotServiceTest {
   void createCapturesRegimeAndPrice() {
     Stock stock = saveStock("000001", BREAKOUT_READY);
     saveCandle(stock, 10_000L);
-    SnapshotCreateRequest request = new SnapshotCreateRequest(stock.getId(), BUY, List.of(), "회고");
+    SnapshotCreateRequest request = new SnapshotCreateRequest(stock.getCode(), BUY, List.of(), "회고");
 
     SnapshotCreateResponse response = snapshotService.create(request);
 
@@ -63,7 +63,7 @@ class SnapshotServiceTest {
   @Test
   @DisplayName("존재하지 않는 종목으로 생성하면 예외")
   void createThrowsWhenStockNotFound() {
-    SnapshotCreateRequest request = new SnapshotCreateRequest(999_999L, BUY, List.of(), "회고");
+    SnapshotCreateRequest request = new SnapshotCreateRequest("999999", BUY, List.of(), "회고");
 
     assertThatThrownBy(() -> snapshotService.create(request))
         .isInstanceOf(CoreException.class);
@@ -81,6 +81,8 @@ class SnapshotServiceTest {
 
     assertThat(detail.referenceSnapshotIds()).containsExactly(ref.getId());
     assertThat(detail.retrospective()).isEqualTo("회고내용");
+    assertThat(detail.judgment()).isEqualTo(BUY);
+    assertThat(detail.stockName()).isEqualTo(stock.getName());
   }
 
   @Test

--- a/apps/stock-api/src/test/java/com/momentum/config/SecurityProtectionTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/config/SecurityProtectionTest.java
@@ -1,0 +1,122 @@
+package com.momentum.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.momentum.infrastructure.auth.JwtAuthenticationFilter;
+import com.momentum.infrastructure.auth.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityProtectionTest {
+
+  @Autowired
+  private MockMvcTester mockMvc;
+  @Autowired
+  private JwtProvider jwtProvider;
+
+  // ===================== 보호 경로 — 토큰 없으면 401 =====================
+
+  @Test
+  @DisplayName("스냅샷 목록은 토큰 없으면 401 + ApiResponse FAIL 포맷")
+  void snapshotListRequiresAuth() {
+    assertThat(mockMvc.get().uri("/api/v1/snapshots"))
+        .hasStatus(HttpStatus.UNAUTHORIZED)
+        .bodyJson().extractingPath("$.meta.result").isEqualTo("FAIL");
+  }
+
+  @Test
+  @DisplayName("스냅샷 상세는 토큰 없으면 401")
+  void snapshotDetailRequiresAuth() {
+    assertThat(mockMvc.get().uri("/api/v1/snapshots/1"))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("스냅샷 생성(POST)은 토큰 없으면 401 (본문 파싱 전에 필터가 차단)")
+  void snapshotCreateRequiresAuth() {
+    assertThat(mockMvc.post().uri("/api/v1/snapshots"))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("관심종목 목록은 토큰 없으면 401")
+  void likeListRequiresAuth() {
+    assertThat(mockMvc.get().uri("/api/v1/stocks/likes"))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("관심종목 추가(POST)는 토큰 없으면 401")
+  void likeAddRequiresAuth() {
+    assertThat(mockMvc.post().uri("/api/v1/stocks/005930/like"))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  // ===================== 보호 경로 — 토큰 유효/무효 =====================
+
+  @Test
+  @DisplayName("유효한 accessToken 쿠키면 필터를 통과한다(401 아님)")
+  void validTokenPassesFilter() {
+    Cookie cookie = accessCookie(jwtProvider.createAccessToken(1L, Instant.now()));
+
+    assertThat(mockMvc.get().uri("/api/v1/snapshots").cookie(cookie))
+        .hasStatusOk();
+  }
+
+  @Test
+  @DisplayName("위조된 토큰이면 401")
+  void forgedTokenIsUnauthorized() {
+    Cookie cookie = accessCookie("not-a-valid-jwt");
+
+    assertThat(mockMvc.get().uri("/api/v1/snapshots").cookie(cookie))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("만료된 토큰이면 401")
+  void expiredTokenIsUnauthorized() {
+    // 1시간 전 기준으로 발급 → exp 가 이미 지난 토큰
+    Cookie cookie = accessCookie(
+        jwtProvider.createAccessToken(1L, Instant.now().minus(Duration.ofHours(1))));
+
+    assertThat(mockMvc.get().uri("/api/v1/snapshots").cookie(cookie))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  // ===================== 공개 경로 — 토큰 없어도 통과 =====================
+
+  @Test
+  @DisplayName("계정 조회는 토큰 없으면 401 (보호 경로)")
+  void accountRequiresAuth() {
+    assertThat(mockMvc.get().uri("/api/v1/auth/account"))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("공개 경로(회원가입)는 토큰 없어도 401이 아니다")
+  void publicEndpointNotBlocked() {
+    assertThat(mockMvc.post().uri("/api/v1/auth/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"email":"pub@momentum.com","password":"pw1234","name":"홍길동","phoneNumber":"01012345678"}
+            """))
+        .hasStatusOk();
+  }
+
+  private Cookie accessCookie(String token) {
+    return new Cookie(JwtAuthenticationFilter.ACCESS_TOKEN_COOKIE, token);
+  }
+}

--- a/apps/stock-api/src/test/java/com/momentum/infrastructure/auth/JwtProviderTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/infrastructure/auth/JwtProviderTest.java
@@ -1,0 +1,87 @@
+package com.momentum.infrastructure.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.momentum.config.JwtProperties;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtProviderTest {
+
+  private static final String SECRET = "test-secret-key-must-be-at-least-32-bytes-long-0123456789";
+  private static final Long MEMBER_ID = 42L;
+
+  private final JwtProvider jwtProvider = new JwtProvider(props(SECRET));
+
+  @Test
+  @DisplayName("accessToken 은 발급한 회원 ID 로 다시 해석된다")
+  void accessTokenRoundTrip() {
+    String token = jwtProvider.createAccessToken(MEMBER_ID, Instant.now());
+
+    assertThat(jwtProvider.resolveMemberId(token)).contains(MEMBER_ID);
+  }
+
+  @Test
+  @DisplayName("refreshToken 도 회원 ID 로 다시 해석된다")
+  void refreshTokenRoundTrip() {
+    String token = jwtProvider.createRefreshToken(MEMBER_ID, Instant.now());
+
+    assertThat(jwtProvider.resolveMemberId(token)).contains(MEMBER_ID);
+  }
+
+  @Test
+  @DisplayName("passwordReset 토큰은 전용 해석기로만 회원 ID 를 돌려준다")
+  void passwordResetTokenRoundTrip() {
+    String token = jwtProvider.createPasswordResetToken(MEMBER_ID, Instant.now());
+
+    assertThat(jwtProvider.resolvePasswordResetMemberId(token)).contains(MEMBER_ID);
+  }
+
+  @Test
+  @DisplayName("일반 accessToken 은 passwordReset 해석기에서 거부된다(purpose 불일치)")
+  void accessTokenRejectedAsPasswordReset() {
+    String accessToken = jwtProvider.createAccessToken(MEMBER_ID, Instant.now());
+
+    assertThat(jwtProvider.resolvePasswordResetMemberId(accessToken)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("같은 시각·같은 회원으로 발급해도 jti 때문에 토큰 문자열이 다르다")
+  void tokensAreUniquePerIssue() {
+    Instant fixed = Instant.now();
+
+    String first = jwtProvider.createAccessToken(MEMBER_ID, fixed);
+    String second = jwtProvider.createAccessToken(MEMBER_ID, fixed);
+
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  @DisplayName("만료된 토큰은 해석되지 않는다(비어있는 Optional)")
+  void expiredTokenIsRejected() {
+    String expired = jwtProvider.createAccessToken(MEMBER_ID, Instant.now().minus(Duration.ofHours(1)));
+
+    assertThat(jwtProvider.resolveMemberId(expired)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("형식이 깨진 토큰은 해석되지 않는다")
+  void malformedTokenIsRejected() {
+    assertThat(jwtProvider.resolveMemberId("not-a-jwt")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("다른 키로 서명된 토큰은 거부된다(서명 검증)")
+  void tokenSignedWithOtherKeyIsRejected() {
+    JwtProvider other = new JwtProvider(props("another-secret-key-also-32-bytes-long-9876543210abc"));
+    String foreign = other.createAccessToken(MEMBER_ID, Instant.now());
+
+    assertThat(jwtProvider.resolveMemberId(foreign)).isEmpty();
+  }
+
+  private static JwtProperties props(String secret) {
+    return new JwtProperties(secret, Duration.ofMinutes(30), Duration.ofDays(14), Duration.ofMinutes(10));
+  }
+}

--- a/apps/stock-api/src/test/java/com/momentum/interfaces/api/auth/AuthV1ControllerTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/interfaces/api/auth/AuthV1ControllerTest.java
@@ -1,0 +1,113 @@
+package com.momentum.interfaces.api.auth;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthV1ControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @DisplayName("GET /csrf 는 csrfToken 쿠키를 발급한다")
+  void csrfIssuesCookie() throws Exception {
+    mockMvc.perform(get("/api/v1/auth/csrf"))
+        .andExpect(status().isOk())
+        .andExpect(cookie().exists("csrfToken"));
+  }
+
+  @Test
+  @DisplayName("회원가입은 CSRF 없이 가능하며 accessToken 과 HttpOnly refreshToken 쿠키를 반환한다")
+  void registerReturnsAccessTokenAndRefreshCookie() throws Exception {
+    mockMvc.perform(post("/api/v1/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(registerBody("reg@momentum.com")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+        .andExpect(cookie().exists("refreshToken"))
+        .andExpect(cookie().httpOnly("refreshToken", true));
+  }
+
+  @Test
+  @DisplayName("로그인은 CSRF 토큰이 없으면 403")
+  void loginWithoutCsrfIsForbidden() throws Exception {
+    mockMvc.perform(post("/api/v1/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(loginBody("nocsrf@momentum.com")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("CSRF 토큰을 포함하면 로그인되어 accessToken 과 refreshToken 쿠키를 반환한다")
+  void loginWithCsrfSucceeds() throws Exception {
+    mockMvc.perform(post("/api/v1/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(registerBody("loginflow@momentum.com")))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(post("/api/v1/auth/login").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(loginBody("loginflow@momentum.com")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+        .andExpect(cookie().exists("refreshToken"));
+  }
+
+  @Test
+  @DisplayName("토큰 없이 계정 조회 시 isLoggedIn=false")
+  void accountWithoutTokenIsLoggedOut() throws Exception {
+    mockMvc.perform(get("/api/v1/auth/account"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.isLoggedIn").value(false));
+  }
+
+  @Test
+  @DisplayName("Bearer accessToken 으로 계정 조회 시 로그인 정보를 반환한다")
+  void accountWithBearerTokenReturnsInfo() throws Exception {
+    MvcResult registered = mockMvc.perform(post("/api/v1/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(registerBody("me@momentum.com")))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String accessToken = objectMapper.readTree(registered.getResponse().getContentAsString())
+        .path("data").path("accessToken").asText();
+
+    mockMvc.perform(get("/api/v1/auth/account").header("Authorization", "Bearer " + accessToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.isLoggedIn").value(true))
+        .andExpect(jsonPath("$.data.userId").isNumber());
+  }
+
+  private String registerBody(String email) {
+    return """
+        {"email":"%s","password":"pw1234","name":"홍길동","phoneNumber":"01012345678"}
+        """.formatted(email);
+  }
+
+  private String loginBody(String email) {
+    return """
+        {"email":"%s","password":"pw1234"}
+        """.formatted(email);
+  }
+}

--- a/apps/stock-api/src/test/java/com/momentum/interfaces/api/auth/AuthV1ControllerTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/interfaces/api/auth/AuthV1ControllerTest.java
@@ -1,21 +1,20 @@
 package com.momentum.interfaces.api.auth;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -24,79 +23,177 @@ import org.springframework.transaction.annotation.Transactional;
 class AuthV1ControllerTest {
 
   @Autowired
-  private MockMvc mockMvc;
-  @Autowired
-  private ObjectMapper objectMapper;
+  private MockMvcTester mockMvc;
 
   @Test
-  @DisplayName("GET /csrf 는 csrfToken 쿠키를 발급한다")
-  void csrfIssuesCookie() throws Exception {
-    mockMvc.perform(get("/api/v1/auth/csrf"))
-        .andExpect(status().isOk())
-        .andExpect(cookie().exists("csrfToken"));
+  @DisplayName("회원가입은 accessToken/refreshToken HttpOnly 쿠키를 반환한다")
+  void registerReturnsAuthCookies() {
+    assertThat(mockMvc.post().uri("/api/v1/auth/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(registerBody("reg@momentum.com")))
+        .hasStatusOk()
+        .cookies()
+        .containsCookie("accessToken").isHttpOnly("accessToken", true)
+        .containsCookie("refreshToken").isHttpOnly("refreshToken", true);
   }
 
   @Test
-  @DisplayName("회원가입은 CSRF 없이 가능하며 accessToken 과 HttpOnly refreshToken 쿠키를 반환한다")
-  void registerReturnsAccessTokenAndRefreshCookie() throws Exception {
-    mockMvc.perform(post("/api/v1/auth/register")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(registerBody("reg@momentum.com")))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
-        .andExpect(cookie().exists("refreshToken"))
-        .andExpect(cookie().httpOnly("refreshToken", true));
+  @DisplayName("발급 쿠키는 HttpOnly·Secure·SameSite=Strict 속성을 갖는다")
+  void authCookiesHaveSecurityAttributes() {
+    MvcTestResult result = register("cookieattr@momentum.com");
+
+    assertThat(result).cookies()
+        .isHttpOnly("accessToken", true).isSecure("accessToken", true)
+        .isHttpOnly("refreshToken", true).isSecure("refreshToken", true);
+
+    // SameSite 는 CookieMapAssert 에 단언 메서드가 없어 Set-Cookie 헤더로 확인한다.
+    List<String> setCookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+    assertThat(setCookies).hasSize(2).allMatch(header -> header.contains("SameSite=Strict"));
   }
 
   @Test
-  @DisplayName("로그인은 CSRF 토큰이 없으면 403")
-  void loginWithoutCsrfIsForbidden() throws Exception {
-    mockMvc.perform(post("/api/v1/auth/login")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(loginBody("nocsrf@momentum.com")))
-        .andExpect(status().isForbidden());
+  @DisplayName("access·refresh 쿠키는 Path 스코프가 다르다")
+  void authCookiesHaveScopedPaths() {
+    assertThat(register("cookiepath@momentum.com")).cookies()
+        .hasPath("accessToken", "/")
+        .hasPath("refreshToken", "/api/v1/auth");
   }
 
   @Test
-  @DisplayName("CSRF 토큰을 포함하면 로그인되어 accessToken 과 refreshToken 쿠키를 반환한다")
-  void loginWithCsrfSucceeds() throws Exception {
-    mockMvc.perform(post("/api/v1/auth/register")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(registerBody("loginflow@momentum.com")))
-        .andExpect(status().isOk());
+  @DisplayName("비밀번호 재설정 토큰 쿠키는 /password 경로로 좁혀진다")
+  void passwordResetCookieIsScoped() {
+    register("cookiereset@momentum.com");
 
-    mockMvc.perform(post("/api/v1/auth/login").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(loginBody("loginflow@momentum.com")))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
-        .andExpect(cookie().exists("refreshToken"));
+    MvcTestResult result = mockMvc.post().uri("/api/v1/auth/password/verify")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"email":"cookiereset@momentum.com","name":"홍길동","phoneNumber":"01012345678"}
+            """)
+        .exchange();
+
+    assertThat(result).cookies()
+        .isHttpOnly("passwordResetToken", true)
+        .isSecure("passwordResetToken", true)
+        .hasPath("passwordResetToken", "/api/v1/auth/password");
   }
 
   @Test
-  @DisplayName("토큰 없이 계정 조회 시 isLoggedIn=false")
-  void accountWithoutTokenIsLoggedOut() throws Exception {
-    mockMvc.perform(get("/api/v1/auth/account"))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.isLoggedIn").value(false));
+  @DisplayName("로그인은 CSRF 토큰 없이 accessToken/refreshToken 쿠키를 반환한다")
+  void loginReturnsAuthCookies() {
+    register("loginflow@momentum.com");
+
+    assertThat(mockMvc.post().uri("/api/v1/auth/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(loginBody("loginflow@momentum.com")))
+        .hasStatusOk()
+        .cookies()
+        .containsCookie("accessToken").containsCookie("refreshToken");
   }
 
   @Test
-  @DisplayName("Bearer accessToken 으로 계정 조회 시 로그인 정보를 반환한다")
-  void accountWithBearerTokenReturnsInfo() throws Exception {
-    MvcResult registered = mockMvc.perform(post("/api/v1/auth/register")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(registerBody("me@momentum.com")))
-        .andExpect(status().isOk())
-        .andReturn();
+  @DisplayName("refreshToken 쿠키로 재발급하면 새 access/refresh 쿠키를 반환한다")
+  void refreshReturnsNewAuthCookies() {
+    Cookie refreshCookie = register("refreshflow@momentum.com").getResponse()
+        .getCookie("refreshToken");
 
-    String accessToken = objectMapper.readTree(registered.getResponse().getContentAsString())
-        .path("data").path("accessToken").asText();
+    assertThat(mockMvc.post().uri("/api/v1/auth/refresh").cookie(refreshCookie))
+        .hasStatusOk()
+        .cookies()
+        .containsCookie("accessToken").containsCookie("refreshToken");
+  }
 
-    mockMvc.perform(get("/api/v1/auth/account").header("Authorization", "Bearer " + accessToken))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.isLoggedIn").value(true))
-        .andExpect(jsonPath("$.data.userId").isNumber());
+  @Test
+  @DisplayName("로그아웃은 access/refresh 쿠키를 만료(Max-Age=0)시킨다")
+  void logoutClearsAuthCookies() {
+    Cookie refreshCookie = register("logoutflow@momentum.com").getResponse()
+        .getCookie("refreshToken");
+
+    assertThat(mockMvc.post().uri("/api/v1/auth/logout").cookie(refreshCookie))
+        .hasStatusOk()
+        .cookies()
+        .hasMaxAge("accessToken", Duration.ZERO).hasMaxAge("refreshToken", Duration.ZERO);
+  }
+
+  @Test
+  @DisplayName("비밀번호 재설정 1단계는 본인확인 성공 시 passwordResetToken 쿠키를 발급한다")
+  void passwordResetVerifyIssuesResetCookie() {
+    register("pwreset@momentum.com");
+
+    assertThat(mockMvc.post().uri("/api/v1/auth/password/verify")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"email":"pwreset@momentum.com","name":"홍길동","phoneNumber":"01012345678"}
+            """))
+        .hasStatusOk()
+        .cookies()
+        .containsCookie("passwordResetToken").isHttpOnly("passwordResetToken", true);
+  }
+
+  @Test
+  @DisplayName("1단계 쿠키로 2단계 비밀번호 변경에 성공하고 재설정 쿠키가 삭제된다")
+  void passwordResetTwoStepFlowSucceeds() {
+    register("pwreset2@momentum.com");
+
+    Cookie resetCookie = mockMvc.post().uri("/api/v1/auth/password/verify")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"email":"pwreset2@momentum.com","name":"홍길동","phoneNumber":"01012345678"}
+            """)
+        .exchange().getResponse().getCookie("passwordResetToken");
+
+    assertThat(mockMvc.post().uri("/api/v1/auth/password/reset").cookie(resetCookie)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"newPassword":"brandnew1234"}
+            """))
+        .hasStatusOk()
+        .cookies().hasMaxAge("passwordResetToken", Duration.ZERO);
+
+    // 변경된 비밀번호로 로그인되는지 확인
+    assertThat(mockMvc.post().uri("/api/v1/auth/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"email":"pwreset2@momentum.com","password":"brandnew1234"}
+            """))
+        .hasStatusOk()
+        .cookies().containsCookie("accessToken");
+  }
+
+  @Test
+  @DisplayName("재설정 토큰 쿠키 없이 2단계를 호출하면 401")
+  void passwordResetConfirmWithoutTokenIsUnauthorized() {
+    assertThat(mockMvc.post().uri("/api/v1/auth/password/reset")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("""
+            {"newPassword":"brandnew1234"}
+            """))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("토큰 없이 계정 조회 시 401 (보호 경로)")
+  void accountRequiresAuth() {
+    assertThat(mockMvc.get().uri("/api/v1/auth/account"))
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("accessToken 쿠키로 계정 조회 시 로그인 정보를 반환한다")
+  void accountWithAccessCookieReturnsInfo() {
+    Cookie accessCookie = register("me@momentum.com").getResponse().getCookie("accessToken");
+
+    MvcTestResult result = mockMvc.get().uri("/api/v1/auth/account").cookie(accessCookie).exchange();
+
+    assertThat(result).hasStatusOk();
+    assertThat(result).bodyJson().extractingPath("$.data.isLoggedIn").isEqualTo(true);
+    assertThat(result).bodyJson().extractingPath("$.data.userId").isNotNull();
+  }
+
+  private MvcTestResult register(String email) {
+    return mockMvc.post().uri("/api/v1/auth/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(registerBody(email))
+        .exchange();
   }
 
   private String registerBody(String email) {

--- a/apps/stock-api/src/test/java/com/momentum/interfaces/api/snapshot/SnapshotV1ControllerTest.java
+++ b/apps/stock-api/src/test/java/com/momentum/interfaces/api/snapshot/SnapshotV1ControllerTest.java
@@ -52,7 +52,7 @@ class SnapshotV1ControllerTest {
     Stock stock = saveStock("000001", BREAKOUT_READY);
     saveCandle(stock, 10_000L);
     String body = objectMapper.writeValueAsString(
-        new SnapshotCreateRequest(stock.getId(), BUY, List.of(), "회고"));
+        new SnapshotCreateRequest(stock.getCode(), BUY, List.of(), "회고"));
 
     assertThat(mockMvcTester.post()
         .uri("/api/v1/snapshots")

--- a/apps/stock-realtime/src/main/java/com/momentum/config/WebConfig.java
+++ b/apps/stock-realtime/src/main/java/com/momentum/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.momentum.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 프론트엔드(다른 포트)가 EventSource(withCredentials)로 SSE 를 구독하므로
+ * credentials 허용 CORS 가 필요하다. 운영 도메인은 환경에 맞게 조정할 것.
+ * (stock-api 의 CORS 정책과 동일한 기조)
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOriginPatterns("http://localhost:*")
+        .allowedMethods("GET", "OPTIONS")
+        .allowedHeaders("*")
+        .allowCredentials(true);
+  }
+}

--- a/apps/stock-realtime/src/main/resources/application.yml
+++ b/apps/stock-realtime/src/main/resources/application.yml
@@ -1,0 +1,61 @@
+server:
+  port: 8081 # stock-api(8080)와 분리. FE 는 VITE_REALTIME_BASE_URL 로 이 주소를 가리킨다.
+  shutdown: graceful
+  tomcat:
+    # SSE 장기 연결을 다수 유지하므로 keep-alive 를 넉넉히 둔다.
+    keep-alive-timeout: 60s
+    connection-timeout: 1m
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: stock-realtime
+  profiles:
+    active: local
+  config:
+    import:
+      # 실행 위치(레포 루트 / 모듈 디렉토리)에 관계없이 env.properties 를 찾도록 둘 다 optional 로 둔다.
+      - optional:file:./env.properties
+      - optional:file:../../env.properties
+      - jpa.yml
+      - logging.yml
+
+# LsWebSocketHandler 가 ls-investment.auth-token 을 사용한다(@Value).
+ls-investment:
+  app-key: ${LS_APP_KEY:1111}
+  secret-key: ${LS_SECRET_KEY:1111}
+  auth-token: ${LS_AUTH_TOKEN:1111}
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/docs/시퀀스 다이어그램.md
+++ b/docs/시퀀스 다이어그램.md
@@ -36,19 +36,36 @@ sequenceDiagram
 
     U->>FE: 앱 진입
     FE->>AUTH: GET /csrf
-    AUTH-->>FE: csrfToken
+    AUTH-->>FE: Set-Cookie csrfToken (HttpOnly=false)
 
     U->>FE: 로그인 입력
     FE->>AUTH: POST /login {email, password}
-    AUTH-->>FE: accessToken
+    AUTH-->>FE: {accessToken} + Set-Cookie refreshToken (HttpOnly)
 
     Note over FE,AUTH: 또는 회원가입
     U->>FE: 회원가입 입력
     FE->>AUTH: POST /register {email, password, name, phoneNumber}
-    AUTH-->>FE: accessToken
+    AUTH-->>FE: {accessToken} + Set-Cookie refreshToken (HttpOnly)
 
     FE->>AUTH: GET /account
     AUTH-->>FE: {isLoggedIn, userId, nickname}
+
+    Note over FE,AUTH: 토큰 재발급 (accessToken 만료 시)
+    FE->>AUTH: POST /refresh (Cookie refreshToken)
+    AUTH-->>FE: {accessToken}
+
+    Note over FE,AUTH: 로그아웃
+    U->>FE: 로그아웃
+    FE->>AUTH: POST /logout
+    AUTH-->>FE: 200 OK + Set-Cookie refreshToken 만료
+
+    Note over FE,AUTH: 아이디·비밀번호 찾기
+    U->>FE: 이메일 찾기 입력
+    FE->>AUTH: POST /email/find {phoneNumber, name}
+    AUTH-->>FE: {email}
+    U->>FE: 비밀번호 찾기 입력
+    FE->>AUTH: POST /password/find {email, name}
+    AUTH-->>FE: 200 OK
 ```
 
 ---
@@ -65,10 +82,10 @@ sequenceDiagram
     participant INSIGHT as /api/v1/stocks/{code}/insight
     participant STOCK as /api/v1/stocks
 
-    Note over FE,RANK_SSE: 페이지 마운트 시 (기본 탭: 돌파시작)
-    FE->>RANK_REST: GET /breakout-start
+    Note over FE,RANK_SSE: 페이지 마운트 시 (기본 탭: 돌파성공)
+    FE->>RANK_REST: GET /breakout-success
     RANK_REST-->>FE: [{stockName, currentPrice, oneYearMomentum, fipScore}]
-    FE-)RANK_SSE: SSE /breakout-start/subscribe
+    FE-)RANK_SSE: SSE /breakout-success/subscribe
     RANK_SSE--)FE: 실시간 업데이트 (지속)
 
     Note over FE,INSIGHT: 랭킹 첫 번째 종목 자동 조회
@@ -83,25 +100,10 @@ sequenceDiagram
 
     Note over FE,RANK_SSE: 탭 클릭 — 돌파준비
     U->>FE: 돌파준비 탭 클릭
-    FE-xRANK_SSE: SSE /breakout-start 구독 해제
+    FE-xRANK_SSE: SSE /breakout-success 구독 해제
     FE->>RANK_REST: GET /breakout-ready
     RANK_REST-->>FE: [{stockName, currentPrice, oneYearMomentum, fipScore}]
     FE-)RANK_SSE: SSE /breakout-ready/subscribe
-    RANK_SSE--)FE: 실시간 업데이트 (지속)
-    Note over FE,INSIGHT: 랭킹 첫 번째 종목 자동 조회
-    FE->>CHART: GET /chart/daily?from=&to=
-    FE->>CHART: GET /chart/bases?from=&to=
-    FE->>INSIGHT: GET /insight/momentum
-    FE->>INSIGHT: GET /insight/fip
-    FE->>INSIGHT: GET /insight/rs
-    INSIGHT-->>FE: 인사이트 반환
-
-    Note over FE,RANK_SSE: 탭 클릭 — 돌파실패
-    U->>FE: 돌파실패 탭 클릭
-    FE-xRANK_SSE: SSE /breakout-ready 구독 해제
-    FE->>RANK_REST: GET /breakout-failed
-    RANK_REST-->>FE: [{stockName, currentPrice, oneYearMomentum, fipScore}]
-    FE-)RANK_SSE: SSE /breakout-failed/subscribe
     RANK_SSE--)FE: 실시간 업데이트 (지속)
     Note over FE,INSIGHT: 랭킹 첫 번째 종목 자동 조회
     FE->>CHART: GET /chart/daily?from=&to=

--- a/docs/시퀀스 다이어그램.md
+++ b/docs/시퀀스 다이어그램.md
@@ -1,5 +1,15 @@
 # Momentum 시퀀스 다이어그램
 
+> 최종 갱신: 2026-06-08 (구현된 백엔드 API 기준)
+
+## 0. 공통 규약
+
+- **응답 래퍼**: 모든 REST 응답은 `ApiResponse<T> = { meta:{result, errorCode, message}, data }`. 아래 다이어그램의 응답은 `data` 부분만 표기.
+- **인증**: accessToken 은 `Authorization: Bearer` 헤더(메모리 보관), refreshToken 은 HttpOnly 쿠키. `POST /auth/login·refresh·logout` 만 CSRF 필요(쿠키 `csrfToken` ↔ 헤더 `X-CSRF-Token`).
+- **base URL**: REST·SSE 모두 `/api/...`. 단 실시간(SSE)은 별도 앱 **stock-realtime(:8081)**, 그 외는 **stock-api(:8080)**.
+- **관심종목**: 현재 명세상 `memberId` 를 쿼리 파라미터로 받음(로그인 계정 userId).
+- **시점 파라미터** `at` 은 `LocalDateTime`(타임존 없음), 차트 `from`=LocalDate / `to`=LocalDateTime.
+
 ---
 
 ## 공통 — 사이드바
@@ -10,12 +20,12 @@ sequenceDiagram
     participant FE as Frontend
     participant STOCK as /api/v1/stocks
 
-    Note over FE,STOCK: 공통 — 사이드바 (앱 전체 공유)
-    FE->>STOCK: GET /stocks/likes
-    STOCK-->>FE: 관심 종목 목록
+    Note over FE,STOCK: 공통 — 사이드바 (로그인 시)
+    FE->>STOCK: GET /stocks/likes?memberId=
+    STOCK-->>FE: {stocks:[{stockCode, stockName}]}
 
     U->>FE: 관심 종목 삭제
-    FE->>STOCK: DELETE /stocks/{code}/like
+    FE->>STOCK: DELETE /stocks/{code}/like?memberId=
     STOCK-->>FE: 200 OK
 
     Note over U,FE: 관심 종목 추가는 종목 상세 페이지에서만 가능
@@ -83,10 +93,10 @@ sequenceDiagram
     participant STOCK as /api/v1/stocks
 
     Note over FE,RANK_SSE: 페이지 마운트 시 (기본 탭: 돌파성공)
-    FE->>RANK_REST: GET /breakout-success
-    RANK_REST-->>FE: [{stockName, currentPrice, oneYearMomentum, fipScore}]
+    FE->>RANK_REST: GET /breakout-success?at=
+    RANK_REST-->>FE: {stocks:[{stockName, stockCode, currentPrice, oneYearMomentum, fipScore}]}
     FE-)RANK_SSE: SSE /breakout-success/subscribe
-    RANK_SSE--)FE: 실시간 업데이트 (지속)
+    RANK_SSE--)FE: event: ranking-update · [{stockName, stockCode, currentPrice, oneYearMomentum, fipScore}] (지속)
 
     Note over FE,INSIGHT: 랭킹 첫 번째 종목 자동 조회
     FE->>CHART: GET /chart/daily?from=&to=
@@ -101,10 +111,10 @@ sequenceDiagram
     Note over FE,RANK_SSE: 탭 클릭 — 돌파준비
     U->>FE: 돌파준비 탭 클릭
     FE-xRANK_SSE: SSE /breakout-success 구독 해제
-    FE->>RANK_REST: GET /breakout-ready
-    RANK_REST-->>FE: [{stockName, currentPrice, oneYearMomentum, fipScore}]
+    FE->>RANK_REST: GET /breakout-ready?at=
+    RANK_REST-->>FE: {stocks:[{stockName, stockCode, currentPrice, oneYearMomentum, fipScore}]}
     FE-)RANK_SSE: SSE /breakout-ready/subscribe
-    RANK_SSE--)FE: 실시간 업데이트 (지속)
+    RANK_SSE--)FE: event: ranking-update · [...] (지속)
     Note over FE,INSIGHT: 랭킹 첫 번째 종목 자동 조회
     FE->>CHART: GET /chart/daily?from=&to=
     FE->>CHART: GET /chart/bases?from=&to=
@@ -148,6 +158,8 @@ sequenceDiagram
     participant SNAP as /api/v1/snapshots
 
     Note over FE,SNAP: 페이지 마운트 시
+    FE->>STOCK: GET /stocks/{code}
+    STOCK-->>FE: {stockCode, stockName, regime, trend}
     FE->>CHART: GET /chart/daily?from=&to=
     CHART-->>FE: {candles[]}
 
@@ -198,9 +210,17 @@ sequenceDiagram
     U->>FE: 지지선/저항선 토글 OFF
     Note over FE: 프론트에서 베이스 제거 (API 없음)
 
+    Note over FE,STOCK: 관심 종목 토글 (로그인 시)
+    U->>FE: 북마크 ON
+    FE->>STOCK: POST /stocks/{code}/like?memberId=
+    STOCK-->>FE: 200 OK
+    U->>FE: 북마크 OFF
+    FE->>STOCK: DELETE /stocks/{code}/like?memberId=
+    STOCK-->>FE: 200 OK
+
     Note over FE,SNAP: 인터랙션
     U->>FE: 스냅샷 기록 버튼
-    FE->>FE: 스냅샷 생성 페이지로 이동 (stockId 전달)
+    FE->>FE: 스냅샷 생성 페이지로 이동 (stockCode 전달)
 ```
 
 ---
@@ -216,64 +236,38 @@ sequenceDiagram
     participant STOCK as /api/v1/stocks
     participant SNAP as /api/v1/snapshots
 
-    Note over FE,SNAP: 페이지 마운트 시
-    FE->>SNAP: GET /snapshots/{id}
-    SNAP-->>FE: {recordedAt, referenceSnapshotIds, retrospective}
-
-    Note over FE,CHART: 과거 차트 로드
-    FE->>CHART: GET /chart/daily?from=&to= (과거 기간)
-    CHART-->>FE: {candles[]}
+    Note over FE,SNAP: 페이지 마운트 시 (종목상세에서 stockCode 전달받음)
+    FE->>STOCK: GET /stocks/{code}
+    STOCK-->>FE: {stockCode, stockName, regime, trend}
+    FE->>SNAP: GET /snapshots?stockName=
+    SNAP-->>FE: 과거 스냅샷 목록 (참고 후보)
 
     Note over FE,CHART: 현재 차트 로드
     FE->>CHART: GET /chart/daily?from=&to= (현재 기간)
     CHART-->>FE: {candles[]}
 
-    Note over FE,INSIGHT: 인사이트 조회 (과거 at=recordedAt · 현재 at=now)
-    FE->>INSIGHT: GET /insight/base-stage?at=recordedAt
+    Note over FE,INSIGHT: 인사이트 조회 (생성은 현재 시점 at=now 만)
     FE->>INSIGHT: GET /insight/base-stage?at=now
-    FE->>INSIGHT: GET /insight/regime?at=recordedAt
     FE->>INSIGHT: GET /insight/regime?at=now
-    FE->>INSIGHT: GET /insight/moving-average?at=recordedAt
     FE->>INSIGHT: GET /insight/moving-average?at=now
-    FE->>INSIGHT: GET /insight/momentum?at=recordedAt
     FE->>INSIGHT: GET /insight/momentum?at=now
-    FE->>INSIGHT: GET /insight/fip?at=recordedAt
     FE->>INSIGHT: GET /insight/fip?at=now
-    FE->>INSIGHT: GET /insight/volume?at=recordedAt
     FE->>INSIGHT: GET /insight/volume?at=now
-    FE->>INSIGHT: GET /insight/rs?at=recordedAt
     FE->>INSIGHT: GET /insight/rs?at=now
-    FE->>INSIGHT: GET /insight/eps?at=recordedAt
     FE->>INSIGHT: GET /insight/eps?at=now
-    INSIGHT-->>FE: 인사이트 8개 × 과거·현재 반환
+    INSIGHT-->>FE: 인사이트 8개 반환
 
-    Note over FE,CHART: 이동평균선 토글 (과거·현재 차트 공통)
-    U->>FE: 50일 토글 ON
-    FE->>CHART: GET /chart/moving-averages?period=MA_50 (과거)
-    FE->>CHART: GET /chart/moving-averages?period=MA_50 (현재)
-    CHART-->>FE: {period, dataPoints[]} x2
-    U->>FE: 50일 토글 OFF
-    Note over FE: 프론트에서 MA_50 제거 (API 없음)
+    Note over FE,CHART: 이동평균선 토글 (50 / 150 / 200)
+    U->>FE: 토글 ON
+    FE->>CHART: GET /chart/moving-averages?period=MA_50|150|200&from=&to=
+    CHART-->>FE: {period, dataPoints[{tradeDate, price}]}
+    U->>FE: 토글 OFF
+    Note over FE: 프론트에서 해당 MA 제거 (API 없음)
 
-    U->>FE: 150일 토글 ON
-    FE->>CHART: GET /chart/moving-averages?period=MA_150 (과거)
-    FE->>CHART: GET /chart/moving-averages?period=MA_150 (현재)
-    CHART-->>FE: {period, dataPoints[]} x2
-    U->>FE: 150일 토글 OFF
-    Note over FE: 프론트에서 MA_150 제거 (API 없음)
-
-    U->>FE: 200일 토글 ON
-    FE->>CHART: GET /chart/moving-averages?period=MA_200 (과거)
-    FE->>CHART: GET /chart/moving-averages?period=MA_200 (현재)
-    CHART-->>FE: {period, dataPoints[]} x2
-    U->>FE: 200일 토글 OFF
-    Note over FE: 프론트에서 MA_200 제거 (API 없음)
-
-    Note over FE,CHART: 지지선/저항선 토글 (과거·현재 차트 공통)
+    Note over FE,CHART: 지지선/저항선 토글
     U->>FE: 지지선/저항선 토글 ON
-    FE->>CHART: GET /chart/bases (과거)
-    FE->>CHART: GET /chart/bases (현재)
-    CHART-->>FE: [{startDate, endDate, supportPrice, resistancePrice}] x2
+    FE->>CHART: GET /chart/bases?from=&to=
+    CHART-->>FE: [{startDate, endDate, supportPrice, resistancePrice}]
     U->>FE: 지지선/저항선 토글 OFF
     Note over FE: 프론트에서 베이스 제거 (API 없음)
 
@@ -295,9 +289,9 @@ sequenceDiagram
     Note over FE,SNAP: 인터랙션
     U->>FE: 판단 선택 (매수·매도·관망) + 메모
     U->>FE: 기록 하기 (referenceSnapshotIds 포함)
-    FE->>SNAP: POST /snapshots {judgment, referenceSnapshotIds, retrospective}
-    SNAP-->>FE: 200 OK
-    FE->>FE: 종목 상세로 복귀
+    FE->>SNAP: POST /snapshots {stockCode, judgment, referenceSnapshotIds, retrospective}
+    SNAP-->>FE: {snapshotId, startDate}
+    FE->>FE: 내 스냅샷 목록으로 이동
 ```
 
 ---
@@ -312,7 +306,8 @@ sequenceDiagram
 
     Note over FE,SNAP: 페이지 마운트 시
     FE->>SNAP: GET /snapshots?startDate=&endDate=&judgments=&regimes=&stockName=
-    SNAP-->>FE: {buyCount, sellCount, watchCount, items[]}
+    SNAP-->>FE: {buyCount, sellCount, watchCount, snapshots:[{snapshotId, stockName, stockCode, stockRegime, judgment, recordedAt, price}]}
+    Note over FE,SNAP: judgments·regimes 는 콤마 구분 단일 파라미터(Spring List 바인딩)
 
     Note over FE,SNAP: 필터 변경 시
     U->>FE: 기간·판단·주식레짐·종목명 필터 조작
@@ -338,61 +333,45 @@ sequenceDiagram
 
     Note over FE,SNAP: 페이지 마운트 시
     FE->>SNAP: GET /snapshots/{id}
-    SNAP-->>FE: {recordedAt, referenceSnapshotIds, retrospective}
+    SNAP-->>FE: {stockName, stockCode, judgment, referenceSnapshotIds, recordedAt, retrospective}
 
-    Note over FE,CHART: 참고 차트 · 스냅샷 차트 로드
-    FE->>CHART: GET /chart/daily?from=&to= (참고 스냅샷 기간)
-    FE->>CHART: GET /chart/daily?from=&to= (스냅샷 기간)
-    CHART-->>FE: {candles[]} x2
+    Note over FE,SNAP: 같은 종목의 과거 스냅샷(참고 후보)
+    FE->>SNAP: GET /snapshots?stockName=
+    SNAP-->>FE: {snapshots:[...]}
 
-    Note over FE,INSIGHT: 인사이트 조회 (at=recordedAt)
-    FE->>INSIGHT: GET /insight/base-stage?at=recordedAt
+    Note over FE,CHART: 차트 로드 (stockCode 기준)
+    FE->>CHART: GET /chart/daily?from=&to=
+    CHART-->>FE: {candles[]}
+
+    Note over FE,INSIGHT: 비교패널 — 과거(at=recordedAt) vs 현재(at=now) diff
     FE->>INSIGHT: GET /insight/regime?at=recordedAt
-    FE->>INSIGHT: GET /insight/moving-average?at=recordedAt
+    FE->>INSIGHT: GET /insight/regime?at=now
     FE->>INSIGHT: GET /insight/momentum?at=recordedAt
-    FE->>INSIGHT: GET /insight/fip?at=recordedAt
-    FE->>INSIGHT: GET /insight/volume?at=recordedAt
-    FE->>INSIGHT: GET /insight/rs?at=recordedAt
-    FE->>INSIGHT: GET /insight/eps?at=recordedAt
-    INSIGHT-->>FE: 인사이트 8개 반환
+    FE->>INSIGHT: GET /insight/momentum?at=now
+    Note over FE,INSIGHT: fip · volume · rs · eps · moving-average 도 동일하게 recordedAt·now 쌍으로 조회
+    INSIGHT-->>FE: 각 지표 과거·현재 값 → ▲▼ 델타 산출
 
-    Note over FE,CHART: 이동평균선 토글 (참고·스냅샷 차트 공통)
-    U->>FE: 50일 토글 ON
-    FE->>CHART: GET /chart/moving-averages?period=MA_50 (참고)
-    FE->>CHART: GET /chart/moving-averages?period=MA_50 (스냅샷)
-    CHART-->>FE: {period, dataPoints[]} x2
-    U->>FE: 50일 토글 OFF
-    Note over FE: 프론트에서 MA_50 제거 (API 없음)
+    Note over FE,CHART: 이동평균선 토글 (50 / 150 / 200)
+    U->>FE: 토글 ON
+    FE->>CHART: GET /chart/moving-averages?period=MA_50|150|200&from=&to=
+    CHART-->>FE: {period, dataPoints[{tradeDate, price}]}
+    U->>FE: 토글 OFF
+    Note over FE: 프론트에서 해당 MA 제거 (API 없음)
 
-    U->>FE: 150일 토글 ON
-    FE->>CHART: GET /chart/moving-averages?period=MA_150 (참고)
-    FE->>CHART: GET /chart/moving-averages?period=MA_150 (스냅샷)
-    CHART-->>FE: {period, dataPoints[]} x2
-    U->>FE: 150일 토글 OFF
-    Note over FE: 프론트에서 MA_150 제거 (API 없음)
-
-    U->>FE: 200일 토글 ON
-    FE->>CHART: GET /chart/moving-averages?period=MA_200 (참고)
-    FE->>CHART: GET /chart/moving-averages?period=MA_200 (스냅샷)
-    CHART-->>FE: {period, dataPoints[]} x2
-    U->>FE: 200일 토글 OFF
-    Note over FE: 프론트에서 MA_200 제거 (API 없음)
-
-    Note over FE,CHART: 지지선/저항선 토글 (참고·스냅샷 차트 공통)
+    Note over FE,CHART: 지지선/저항선 토글
     U->>FE: 지지선/저항선 토글 ON
-    FE->>CHART: GET /chart/bases (참고)
-    FE->>CHART: GET /chart/bases (스냅샷)
-    CHART-->>FE: [{startDate, endDate, supportPrice, resistancePrice}] x2
+    FE->>CHART: GET /chart/bases?from=&to=
+    CHART-->>FE: [{startDate, endDate, supportPrice, resistancePrice}]
     U->>FE: 지지선/저항선 토글 OFF
     Note over FE: 프론트에서 베이스 제거 (API 없음)
 
     Note over U,FE: 참고 스냅샷 선택
-    U->>FE: 참고 스냅샷 체크 (프론트에서만 처리)
+    U->>FE: 과거 스냅샷 체크 → referenceSnapshotIds 구성 (snapshotId 기준)
 
     Note over FE,SNAP: 인터랙션
     U->>FE: 판단·메모 수정
     U->>FE: 수정 하기 (referenceSnapshotIds 포함)
-    FE->>SNAP: PATCH /snapshots/{id} {judgment, referenceSnapshotIds, retrospective}
+    FE->>SNAP: PATCH /snapshots/{id} {snapshotId, judgment, referenceSnapshotIds, retrospective}
     SNAP-->>FE: 200 OK
     FE->>FE: 내 스냅샷 목록으로 복귀
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,5 @@ springDocOpenApiVersion=2.7.0
 springMockkVersion=4.0.2
 mockitoVersion=5.14.0
 instancioJUnitVersion=5.0.2
+jjwtVersion=0.12.6
 


### PR DESCRIPTION
## 📌 Summary

JWT 기반 인증 로직을 구성했습니다. **access + refresh 토큰을 httpOnly 쿠키로 발급**하고,
refresh는 DB 화이트리스트로 무효화(로그아웃/회전)하며, 비밀번호 재설정을 2단계로,
snapshot·like·account 엔드포인트에 인증을 강제합니다.

## 🔑 핵심 설계

**access(짧음, 서명만) + refresh(김, DB 활용)**
- access(30m): 매 요청 **서명·만료만** 검증 → DB 안 봄(stateless 유지). 무효화는 짧은 만료에 위임.
- refresh(14d): **별도 테이블(`RefreshToken`) 화이트리스트** + soft delete(`deletedAt`). 무효화 확인은 `/refresh`·`/logout` 때만 DB 조회 → 매 요청 DB 조회 회피.
- 재발급 시 **회전(rotation)**: 옛 refresh soft delete + 새 access·refresh 발급.
- 무효화를 원하면 DB확인 필요는 반드시 생긴다 → 그 조회를 토큰 2개를 활용함으로써 **매 요청 → 갱신 시점으로 최소화**한 구조.

**쿠키 보안**
- 모든 인증 쿠키: `HttpOnly`(XSS 방어) + `Secure` + `SameSite=Strict`(CSRF 방어).
- **Path 스코프로 노출 최소화**: `accessToken`=`/`, `refreshToken`=`/api/v1/auth`, `passwordResetToken`=`/api/v1/auth/password`.
- 같은 도메인 + SameSite=Strict로 CSRF를 막으므로 **CSRF 토큰은 비활성**.

**비밀번호 재설정 — 2단계**
- 1단계 `/password/verify`: 이메일·이름·전화로 본인확인 → `purpose=PASSWORD_RESET` 단수명(10m) JWT를 쿠키로 발급.
- 2단계 `/password/reset`: 그 토큰으로 `memberId` 추출해 비밀번호 변경. 토큰이 신원 운반 + 1단계 통과 증거 역할(stateless 결속).

**인증 강제 (필터 + 인가)**
- `JwtAuthenticationFilter`가 보호 경로(`/snapshots/**`, `/stocks/*/like`, `/stocks/likes`, `/auth/account`)에서 토큰 없으면 **401**. 그 외는 공개.
- 필터 예외는 MVC 바깥이라 `HandlerExceptionResolver`로 `ApiControllerAdvice`에 넘겨 기존 `ApiResponse` 401 포맷으로 변환.
- 보호 경로는 SecurityConfig `.authenticated()`로도 명시(단일 상수 `PROTECTED_PATTERNS` 공유).

## 📂 주요 변경

| 영역 | 내용 |
|---|---|
| 발급/검증 | `JwtProvider`(JJWT, HS256, `jti`로 토큰 유일성, `now`는 파라미터 주입) |
| 화이트리스트 | `RefreshToken` 엔티티 + Repository(soft delete 무효화) |
| 엔드포인트 | `/login` `/register` `/refresh` `/logout` `/email/find` `/password/verify` `/password/reset` `/account` |
| 필터/인가 | `JwtAuthenticationFilter`(쿠키에서 access 추출·검증), `SecurityConfig`(stateless·CSRF off·보호 경로) |
| 설정 | 토큰 만료시간 env 변수화(`JWT_*_VALIDITY`), 시크릿 키 env 주입 |

## ✅ 테스트 (4 클래스 / 51개)

- `JwtProviderTest`(8) — 라운드트립, purpose 격리, jti 유일성, 만료·위조·다른 키 서명 거부
- `AuthServiceTest`(21) — 가입/로그인/재발급 회전·무효화/비번재설정 2단계·만료
- `AuthV1ControllerTest`(12) — 쿠키 발급/HttpOnly·Secure·SameSite·Path 스코프/플로우
- `SecurityProtectionTest`(10) — 보호 경로 401, 유효 토큰 통과, 위조·만료 401, 공개 미차단

## 📝 참고 / 후속

- refresh 토큰은 현재 평문 저장 → 추후 해시 저장 고려.
- 비밀번호 재설정은 메일 인프라 도입 시 **이메일 링크 방식(2차 인증)**으로 이행 예정.
- 운영 배포 시 프론트·API를 같은 상위 도메인으로 묶어 SameSite=Strict 유지(다른 도메인이면 `None`+CSRF 토큰 필요).


Close #33 